### PR TITLE
Remove extra / to build debuginfo correctly

### DIFF
--- a/configure
+++ b/configure
@@ -8179,7 +8179,7 @@ fi
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking for JAVA_HOME using java in /etc/alternatives" >&5
 $as_echo_n "checking for JAVA_HOME using java in /etc/alternatives... " >&6; }
       # We have to get JDK directory, not JRE directory
-      JDK_DIR=`$READLINK -f "$JAVA_PATH" 2>$DEVNULL | $SED -e 's:\(jre/\|\)bin/java::g' 2>$DEVNULL`
+      JDK_DIR=`$READLINK -f "$JAVA_PATH" 2>$DEVNULL | $SED -e 's:/\(jre/\|\)bin/java::g' 2>$DEVNULL`
       if test $? -ne 0 ; then
         JDK_DIR=""
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -210,7 +210,7 @@ else
     else
       AC_MSG_CHECKING([for JAVA_HOME using java in /etc/alternatives])
       # We have to get JDK directory, not JRE directory
-      JDK_DIR=`$READLINK -f "$JAVA_PATH" 2>$DEVNULL | $SED -e 's:\(jre/\|\)bin/java::g' 2>$DEVNULL`
+      JDK_DIR=`$READLINK -f "$JAVA_PATH" 2>$DEVNULL | $SED -e 's:/\(jre/\|\)bin/java::g' 2>$DEVNULL`
       if test $? -ne 0 ; then
         JDK_DIR=""
         AC_MSG_RESULT([not found])


### PR DESCRIPTION
An extra / make debuginfo package fail to build as below.

``` bash
$ rpmbuild -ba heapstats.spec
:
extracting debug info from /home/mockbuild/rpmbuild/BUILDROOT/heapstats-2.0.0-0.fc23.x86_64/usr/lib64/heapstats/heapstats-engines/libheapstats-engine-avx-2.0.so
/usr/lib/rpm/debugedit: canonicalization unexpectedly shrank by one character
```

More detailed information is as here: https://bugzilla.redhat.com/show_bug.cgi?id=304121
