### PR TITLE
Improve the versioning by maven

### DIFF
--- a/analyzer/cli/pom.xml
+++ b/analyzer/cli/pom.xml
@@ -23,9 +23,11 @@
     <parent>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
         <artifactId>heapstats</artifactId>
-        <version>2.0</version>
+        <version>${project.version}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
+
+    <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-cli</artifactId>
     <packaging>jar</packaging>
     <name>HeapStats CLI</name>
@@ -39,7 +41,7 @@
     <organization>
         <name>NTT OSS Center</name>
     </organization>
-    
+
     <build>
         <plugins>
             <plugin>

--- a/analyzer/cli/src/main/assembly/distribution.xml
+++ b/analyzer/cli/src/main/assembly/distribution.xml
@@ -14,7 +14,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>heapstats-cli-2.0</outputDirectory>
+            <outputDirectory>heapstats-cli-${project.version}</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
@@ -26,7 +26,7 @@
             <scope>runtime</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-            <outputDirectory>heapstats-cli-2.0/lib</outputDirectory>
+            <outputDirectory>heapstats-cli-${project.version}/lib</outputDirectory>
         </dependencySet>
     </dependencySets>
 

--- a/analyzer/core/pom.xml
+++ b/analyzer/core/pom.xml
@@ -20,9 +20,15 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>jp.co.ntt.oss.heapstats</groupId>
+        <artifactId>heapstats</artifactId>
+        <version>${project.version}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-core</artifactId>
-    <version>2.0</version>
     <packaging>jar</packaging>
     <name>HeapStats Analyzer Core</name>
     <properties>
@@ -30,12 +36,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.0</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
     <organization>
         <name>NTT OSS Center</name>
     </organization>

--- a/analyzer/fx/pom.xml
+++ b/analyzer/fx/pom.xml
@@ -23,13 +23,12 @@
     <parent>
         <artifactId>heapstats</artifactId>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <version>2.0</version>
+        <version>${project.version}</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-analyzer</artifactId>
-    <version>2.0</version>
     <packaging>jar</packaging>
 
     <name>HeapStats Analyzer</name>

--- a/analyzer/fx/src/main/assembly/distribution.xml
+++ b/analyzer/fx/src/main/assembly/distribution.xml
@@ -32,7 +32,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <fileSets>
         <fileSet>
-            <outputDirectory>heapstats-analyzer-2.0</outputDirectory>
+            <outputDirectory>heapstats-analyzer-${project.version}</outputDirectory>
             <includes>
                 <include>filterDefine.xsd</include>
                 <include>heapstats.properties</include>
@@ -40,21 +40,21 @@
         </fileSet>
         <fileSet>
             <directory>${project.build.directory}</directory>
-            <outputDirectory>heapstats-analyzer-2.0</outputDirectory>
+            <outputDirectory>heapstats-analyzer-${project.version}</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${pom.basedir}/lib</directory>
-            <outputDirectory>heapstats-analyzer-2.0/lib</outputDirectory>
+            <outputDirectory>heapstats-analyzer-${project.version}/lib</outputDirectory>
             <includes>
                 <include>*.jar</include>
             </includes>
         </fileSet>
         <fileSet>
             <directory>${pom.basedir}</directory>
-            <outputDirectory>heapstats-analyzer-2.0</outputDirectory>
+            <outputDirectory>heapstats-analyzer-${project.version}</outputDirectory>
             <includes>
                 <include>THIRD_PARTY_README</include>
             </includes>
@@ -66,7 +66,7 @@
             <scope>runtime</scope>
             <useProjectArtifact>false</useProjectArtifact>
             <outputFileNameMapping>${artifact.artifactId}.${artifact.extension}</outputFileNameMapping>
-            <outputDirectory>heapstats-analyzer-2.0/lib</outputDirectory>
+            <outputDirectory>heapstats-analyzer-${project.version}/lib</outputDirectory>
         </dependencySet>
     </dependencySets>
 

--- a/mbean/java/pom.xml
+++ b/mbean/java/pom.xml
@@ -20,9 +20,15 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>jp.co.ntt.oss.heapstats</groupId>
+        <artifactId>heapstats</artifactId>
+        <version>${project.version}</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-mbean</artifactId>
-    <version>2.0</version>
     <packaging>jar</packaging>
     <name>HeapStats MBean Java Module</name>
     <properties>
@@ -30,12 +36,6 @@
         <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
     </properties>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.0</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
     <organization>
         <name>NTT OSS Center</name>
     </organization>


### PR DESCRIPTION
All components do not have specific version, so the version elements of pom.xml and distribution.xml files should follow to ${project.version}.
