### PR TITLE
Support maven 3.0 and 2.2

### DIFF
--- a/analyzer/cli/pom.xml
+++ b/analyzer/cli/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
         <artifactId>heapstats</artifactId>
-        <version>${project.version}</version>
+        <version>2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/analyzer/core/pom.xml
+++ b/analyzer/core/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
         <artifactId>heapstats</artifactId>
-        <version>${project.version}</version>
+        <version>2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/analyzer/fx/pom.xml
+++ b/analyzer/fx/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>heapstats</artifactId>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <version>${project.version}</version>
+        <version>2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/mbean/java/pom.xml
+++ b/mbean/java/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>jp.co.ntt.oss.heapstats</groupId>
         <artifactId>heapstats</artifactId>
-        <version>${project.version}</version>
+        <version>2.0</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Now, pom.xml do not support older maven, so jenkins failed as below.

http://icedtea.classpath.org/pipermail/heapstats/2016-February/001402.html
http://icedtea.classpath.org/pipermail/heapstats/2016-February/001404.html

Thus I modified patch to support older maven, and modified release.sh to change the version automatically.

I tested that this change can build correctly by maven 3.0.5 and 2.2.1.
