### PR TITLE
Bug2847: LogLevel cannot change through JMX.

### DIFF
--- a/agent/src/heapstats-engines/configuration.cpp
+++ b/agent/src/heapstats-engines/configuration.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file configuration.cpp
  * \brief This file treats HeapStats configuration.
- * Copyright (C) 2014-2015 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -99,7 +99,7 @@ void TConfiguration::initializeConfig(const TConfiguration *src) {
                                             &setOnewayBooleanValue);
     triggerOnLogLock = new TBooleanConfig(this, "trigger_on_loglock", true);
     rankLevel = new TIntConfig(this, "rank_level", 5);
-    logLevel = new TLogLevelConfig(this, "loglevel", INFO);
+    logLevel = new TLogLevelConfig(this, "loglevel", INFO, &setLogLevel);
     order = new TRankOrderConfig(this, "rank_order", DELTA);
     alertPercentage = new TIntConfig(this, "alert_percentage", 50);
     heapAlertPercentage = new TIntConfig(this, "javaheap_alert_percentage", 95);
@@ -770,3 +770,10 @@ bool TConfiguration::isSupportSignal(char const *sigName) {
 
   return false;
 }
+
+void TConfiguration::setLogLevel(TConfiguration *inst,
+                                 TLogLevel val, TLogLevel *dest) {
+  *dest = val;
+  logger->setLogLevel(val);
+}
+

--- a/agent/src/heapstats-engines/configuration.hpp
+++ b/agent/src/heapstats-engines/configuration.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file configuration.hpp
  * \brief This file treats HeapStats configuration.
- * Copyright (C) 2014-2015 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -468,6 +468,8 @@ class TConfiguration {
   void initializeConfig(const TConfiguration *src);
 
   /* Setters */
+  static void setLogLevel(TConfiguration *inst, TLogLevel val, TLogLevel *dest);
+
   static void setOnewayBooleanValue(TConfiguration *inst, bool val,
                                     bool *dest) {
     if (inst->isLoaded && !(*dest) && val) {


### PR DESCRIPTION
This PR is [Bug 2847](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2847) .

I could not change log level through JMX interface (HeapStatsMBean) .

The logger (TLogger) uses logLevel private field in TLogger, it does not refer
to current configuration.
We need to set new log level to logger variable if we want to change it.

I want to add new setter function to LogLevel element in TConfiguration.
That custom function will set new log level to logger.
