### PR TITLE
Bug2848: Show new configuration when it changed through JMX.

### DIFF
--- a/agent/src/heapstats-engines/heapstatsMBean.cpp
+++ b/agent/src/heapstats-engines/heapstatsMBean.cpp
@@ -598,6 +598,8 @@ JNIEXPORT jboolean JNICALL
   if (!env->ExceptionOccurred()) {
     if (new_conf.validate()) {
       conf->merge(&new_conf);
+      logger->printInfoMsg("Configuration has been changed through JMX.");
+      conf->printSetting();
       result = JNI_TRUE;
     } else {
       raiseException(env, "java/lang/IllegalArgumentException",


### PR DESCRIPTION
This PR is [Bug 2848](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2848) .

Currently, user changes configuration through JMX, we cannot check it through
HeapStats log.
I want to check it through log or stdout.
