### PR TITLE
Bug 2860: configure should regard $JAVA_HOME

### DIFF
--- a/configure
+++ b/configure
@@ -8088,6 +8088,10 @@ if test -n "$with_jdk"; then
   JDK_DIR="$with_jdk"
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $JDK_DIR" >&5
 $as_echo "$JDK_DIR" >&6; }
+elif test -n "$JAVA_HOME"; then
+  JDK_DIR="$JAVA_HOME"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $JDK_DIR" >&5
+$as_echo "$JDK_DIR" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: none" >&5
 $as_echo "none" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -199,6 +199,9 @@ AC_MSG_CHECKING([for JAVA_HOME using configure arguments])
 if test -n "$with_jdk"; then
   JDK_DIR="$with_jdk"
   AC_MSG_RESULT($JDK_DIR)
+elif test -n "$JAVA_HOME"; then
+  JDK_DIR="$JAVA_HOME"
+  AC_MSG_RESULT($JDK_DIR)
 else
   AC_MSG_RESULT(none)
   AC_PATH_PROG([JAVA_PATH], [java], [], [/etc/alternatives])


### PR DESCRIPTION
HeapStats user reports that configure script is ignore $JAVA_HOME value.
We should handle $JAVA_HOME in configure.ac .
Of course, HeapStats user should be able to override it through --with-jdk .
