### PR TITLE
Bug 2796: Change default value: snmp_send to false.

### DIFF
--- a/agent/heapstats.conf.in
+++ b/agent/heapstats.conf.in
@@ -56,7 +56,7 @@ thread_record_filename=heapstats-thread-records.htr
 thread_record_iotracer=@IOTRACER@
 
 # Snmp setting
-snmp_send=true
+snmp_send=false
 snmp_target=localhost
 snmp_comname=public
 

--- a/agent/src/heapstats-engines/configuration.cpp
+++ b/agent/src/heapstats-engines/configuration.cpp
@@ -128,7 +128,7 @@ void TConfiguration::initializeConfig(const TConfiguration *src) {
         (char *)DEFAULT_CONF_DIR "/IoTrace.class",
         &ReadStringValue, (TStringConfig::TFinalizer) & free);
     snmpSend =
-        new TBooleanConfig(this, "snmp_send", true, &setOnewayBooleanValue);
+        new TBooleanConfig(this, "snmp_send", false, &setOnewayBooleanValue);
     snmpTarget =
         new TStringConfig(this, "snmp_target", (char *)"localhost",
                           &setSnmpTarget, (TStringConfig::TFinalizer) & free);


### PR DESCRIPTION
Bug 2796: Change default value: snmp_send to false. 
I've created a patch for [Bug 2796](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2796) .
Could you review it?
