### PR TITLE
Bug 2879: Unnecessary varbind is sent in log collection trap.

### DIFF
--- a/agent/src/heapstats-engines/logMain.cpp
+++ b/agent/src/heapstats-engines/logMain.cpp
@@ -198,7 +198,6 @@ void JNICALL OnResourceExhausted(jvmtiEnv *jvmti, JNIEnv *env, jint flags,
   if (conf->SnmpSend()->get()) {
     /* Trap OID. */
     char trapOID[50] = OID_RESALERT;
-    oid OID_ALERT_DATE[] = {SNMP_OID_HEAPALERT, 1};
     oid OID_RES_FLAG[] = {SNMP_OID_RESALERT, 1};
     oid OID_RES_DESC[] = {SNMP_OID_RESALERT, 2};
     char buff[256] = {0};
@@ -213,11 +212,6 @@ void JNICALL OnResourceExhausted(jvmtiEnv *jvmti, JNIEnv *env, jint flags,
 
       /* Setting trapOID. */
       sender.setTrapOID(trapOID);
-
-      /* Set alert date. */
-      snprintf(buff, 255, "%llu", nowTime);
-      sender.addValue(OID_ALERT_DATE, OID_LENGTH(OID_ALERT_DATE), buff,
-                      SNMP_VAR_TYPE_COUNTER64);
 
       /* Set resource inforomation flags. */
       snprintf(buff, 255, "%d", flags);

--- a/agent/src/heapstats-engines/logManager.cpp
+++ b/agent/src/heapstats-engines/logManager.cpp
@@ -1062,7 +1062,6 @@ bool TLogManager::sendLogArchiveTrap(TInvokeCause cause, TMSecTime nowTime,
   if (conf->SnmpSend()->get()) {
     /* Trap OID. */
     char trapOID[50] = OID_LOGARCHIVE;
-    oid OID_ALERT_DATE[] = {SNMP_OID_HEAPALERT, 1};
     oid OID_LOG_PATH[] = {SNMP_OID_LOGARCHIVE, 1};
     oid OID_TROUBLE_DATE[] = {SNMP_OID_LOGARCHIVE, 2};
     /* Temporary buffer. */
@@ -1078,11 +1077,6 @@ bool TLogManager::sendLogArchiveTrap(TInvokeCause cause, TMSecTime nowTime,
 
       /* Setting trapOID. */
       sender.setTrapOID(trapOID);
-
-      /* Set alert date. */
-      snprintf(buff, 255, "%llu", (TMSecTime)getNowTimeSec());
-      sender.addValue(OID_ALERT_DATE, OID_LENGTH(OID_ALERT_DATE), buff,
-                      SNMP_VAR_TYPE_COUNTER64);
 
       /* Set log archive path. */
       sender.addValue(OID_LOG_PATH, OID_LENGTH(OID_LOG_PATH), realSendPath,


### PR DESCRIPTION
I created a patch for [Bug 2879](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2879) .
Please review it.
