### PR TITLE
Bug 2925: [REGRESSION] Cannot attach HeapStats agent to live process

### DIFF
--- a/agent/src/heapstats-engines/deadlockFinder.cpp
+++ b/agent/src/heapstats-engines/deadlockFinder.cpp
@@ -397,7 +397,7 @@ void TDeadlockFinder::setCapabilities(jvmtiCapabilities *capabilities,
    * See also:
    *   hotspot/src/share/vm/prims/jvmtiManageCapabilities.cpp
    */
-  if (!isOnLoad) {
+  if (isOnLoad) {
     capabilities->can_get_owned_monitor_stack_depth_info = 1;
     capabilities->can_get_current_contended_monitor = 1;
   }


### PR DESCRIPTION
This PR is [Bug 2925](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2925) .
Please review it.
