### PR TITLE
Adapting to JDK 9 Phase 2

### DIFF
--- a/agent/src/heapstats-engines/arch/arm/armBitMapMarker.cpp
+++ b/agent/src/heapstats-engines/arch/arm/armBitMapMarker.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file armBitMapMarker.cpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,7 +26,7 @@
  * \brief Mark GC-marked address in this bitmap.
  * \param addr [in] Oop address.
  */
-void TARMBitMapMarker::setMark(void *addr) {
+void TARMBitMapMarker::setMark(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return;
@@ -60,7 +60,7 @@ void TARMBitMapMarker::setMark(void *addr) {
  * \param addr [in] Oop address.
  * \return Designated pointer is marked.
  */
-bool TARMBitMapMarker::checkAndMark(void *addr) {
+bool TARMBitMapMarker::checkAndMark(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return false;

--- a/agent/src/heapstats-engines/arch/arm/armBitMapMarker.hpp
+++ b/agent/src/heapstats-engines/arch/arm/armBitMapMarker.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file armBitMapMarker.hpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,7 @@ class TARMBitMapMarker : public TBitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TARMBitMapMarker(void *startAddr, size_t size)
+  TARMBitMapMarker(const void *startAddr, const size_t size)
       : TBitMapMarker(startAddr, size){};
 
   /*!
@@ -48,14 +48,14 @@ class TARMBitMapMarker : public TBitMapMarker {
    * \brief Mark GC-marked address in this bitmap.
    * \param addr [in] Oop address.
    */
-  virtual void setMark(void *addr);
+  virtual void setMark(const void *addr);
 
   /*!
    * \brief Check address which is already marked and set mark.
    * \param addr [in] Oop address.
    * \return Designated pointer is marked.
    */
-  virtual bool checkAndMark(void *addr);
+  virtual bool checkAndMark(const void *addr);
 };
 
 #endif  // ARMBITMAPMARKER_HPP

--- a/agent/src/heapstats-engines/arch/arm/neon/neonBitMapMarker.hpp
+++ b/agent/src/heapstats-engines/arch/arm/neon/neonBitMapMarker.hpp
@@ -2,7 +2,7 @@
  * \file neonBitMapMarker.hpp
  * \brief Storeing and Controlling G1 marking bitmap.
  *        This source is optimized for NEON instruction set.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ class TNeonBitMapMarker : public TARMBitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TNeonBitMapMarker(void *startAddr, size_t size)
+  TNeonBitMapMarker(const void *startAddr, const size_t size)
       : TARMBitMapMarker(startAddr, size){};
 
   /*!

--- a/agent/src/heapstats-engines/arch/x86/avx/avxBitMapMarker.hpp
+++ b/agent/src/heapstats-engines/arch/x86/avx/avxBitMapMarker.hpp
@@ -2,7 +2,7 @@
  * \file avxBitMapMarker.hpp
  * \brief Storeing and Controlling G1 marking bitmap.
  *        This source is optimized for AVX instruction set.
- * Copyright (C) 2014 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ class TAVXBitMapMarker : public TSSE2BitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TAVXBitMapMarker(void *startAddr, size_t size)
+  TAVXBitMapMarker(const void *startAddr, const size_t size)
       : TSSE2BitMapMarker(startAddr, size){};
 
   /*!

--- a/agent/src/heapstats-engines/arch/x86/sse2/sse2BitMapMarker.hpp
+++ b/agent/src/heapstats-engines/arch/x86/sse2/sse2BitMapMarker.hpp
@@ -2,7 +2,7 @@
  * \file sse2BitMapMarker.hpp
  * \brief Storeing and Controlling G1 marking bitmap.
  *        This source is optimized for SSE2 instruction set.
- * Copyright (C) 2014 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -35,7 +35,7 @@ class TSSE2BitMapMarker : public TX86BitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TSSE2BitMapMarker(void *startAddr, size_t size)
+  TSSE2BitMapMarker(const void *startAddr, const size_t size)
       : TX86BitMapMarker(startAddr, size){};
 
   /*!

--- a/agent/src/heapstats-engines/arch/x86/x86BitMapMarker.cpp
+++ b/agent/src/heapstats-engines/arch/x86/x86BitMapMarker.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file x86BitMapMarker.cpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2014 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -26,7 +26,7 @@
  * \brief Mark GC-marked address in this bitmap.
  * \param addr [in] Oop address.
  */
-void TX86BitMapMarker::setMark(void *addr) {
+void TX86BitMapMarker::setMark(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return;
@@ -60,7 +60,7 @@ void TX86BitMapMarker::setMark(void *addr) {
  * \param addr [in] Targer pointer.
  * \return Designated pointer is marked.
  */
-bool TX86BitMapMarker::isMarked(void *addr) {
+bool TX86BitMapMarker::isMarked(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return false;
@@ -99,7 +99,7 @@ bool TX86BitMapMarker::isMarked(void *addr) {
  * \param addr [in] Oop address.
  * \return Designated pointer is marked.
  */
-bool TX86BitMapMarker::checkAndMark(void *addr) {
+bool TX86BitMapMarker::checkAndMark(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return false;

--- a/agent/src/heapstats-engines/arch/x86/x86BitMapMarker.hpp
+++ b/agent/src/heapstats-engines/arch/x86/x86BitMapMarker.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file x86BitMapMarker.hpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2014-2015 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -34,7 +34,7 @@ class TX86BitMapMarker : public TBitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TX86BitMapMarker(void *startAddr, size_t size)
+  TX86BitMapMarker(const void *startAddr, const size_t size)
       : TBitMapMarker(startAddr, size){};
 
   /*!
@@ -46,21 +46,21 @@ class TX86BitMapMarker : public TBitMapMarker {
    * \brief Mark GC-marked address in this bitmap.
    * \param addr [in] Oop address.
    */
-  virtual void setMark(void *addr);
+  virtual void setMark(const void *addr);
 
   /*!
    * \brief Get marked flag of designated pointer.
    * \param addr [in] Targer pointer.
    * \return Designated pointer is marked.
    */
-  virtual bool isMarked(void *addr);
+  virtual bool isMarked(const void *addr);
 
   /*!
    * \brief Check address which is already marked and set mark.
    * \param addr [in] Oop address.
    * \return Designated pointer is marked.
    */
-  virtual bool checkAndMark(void *addr);
+  virtual bool checkAndMark(const void *addr);
 };
 
 #endif  // X86BITMAPMARKER_HPP

--- a/agent/src/heapstats-engines/bitMapMarker.cpp
+++ b/agent/src/heapstats-engines/bitMapMarker.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file bitMapMarker.cpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -30,7 +30,7 @@
  * \param startAddr [in] Start address of Java heap.
  * \param size      [in] Max Java heap size.
  */
-TBitMapMarker::TBitMapMarker(void *startAddr, size_t size) {
+TBitMapMarker::TBitMapMarker(const void *startAddr, const size_t size) {
   /* Sanity check. */
   if (unlikely(startAddr == NULL || size <= 0)) {
     throw - 1;
@@ -39,7 +39,7 @@ TBitMapMarker::TBitMapMarker(void *startAddr, size_t size) {
   /* Initialize setting. */
   size_t alignedSize = ALIGN_SIZE_UP(size, systemPageSize);
 
-  this->beginAddr = startAddr;
+  this->beginAddr = const_cast<void *>(startAddr);
   this->endAddr = incAddress(this->beginAddr, alignedSize);
   this->bitmapSize = ALIGN_SIZE_UP(alignedSize >> MEMALIGN_BIT, systemPageSize);
   this->bitmapAddr = mmap(NULL, this->bitmapSize, PROT_READ | PROT_WRITE,
@@ -70,7 +70,7 @@ TBitMapMarker::~TBitMapMarker() {
  * \param addr [in] Targer pointer.
  * \return Designated pointer is marked.
  */
-bool TBitMapMarker::isMarked(void *addr) {
+bool TBitMapMarker::isMarked(const void *addr) {
   /* Sanity check. */
   if (unlikely(!this->isInZone(addr))) {
     return false;

--- a/agent/src/heapstats-engines/bitMapMarker.hpp
+++ b/agent/src/heapstats-engines/bitMapMarker.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file bitMapMarker.hpp
  * \brief This file is used to store and control of bit map.
- * Copyright (C) 2011-2014 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -80,7 +80,7 @@ class TBitMapMarker {
    * \param startAddr [in] Start address of Java heap.
    * \param size      [in] Max Java heap size.
    */
-  TBitMapMarker(void *startAddr, size_t size);
+  TBitMapMarker(const void *startAddr, const size_t size);
   /*!
    * \brief TBitMapMarker destructor.
    */
@@ -91,7 +91,7 @@ class TBitMapMarker {
    * \param addr [in] Oop address.
    * \return Designated pointer is existing in bitmap.
    */
-  inline bool isInZone(void *addr) {
+  inline bool isInZone(const void *addr) {
     return (this->beginAddr <= addr) && (this->endAddr >= addr);
   }
 
@@ -99,21 +99,21 @@ class TBitMapMarker {
    * \brief Mark GC-marked address in this bitmap.
    * \param addr [in] Oop address.
    */
-  virtual void setMark(void *addr) = 0;
+  virtual void setMark(const void *addr) = 0;
 
   /*!
    * \brief Get marked flag of designated pointer.
    * \param addr [in] Targer pointer.
    * \return Designated pointer is marked.
    */
-  virtual bool isMarked(void *addr);
+  virtual bool isMarked(const void *addr);
 
   /*!
    * \brief Check address which is already marked and set mark.
    * \param addr [in] Oop address.
    * \return Designated pointer is marked.
    */
-  virtual bool checkAndMark(void *addr) = 0;
+  virtual bool checkAndMark(const void *addr) = 0;
 
   /*!
    * \brief Clear bitmap flag.
@@ -138,7 +138,8 @@ class TBitMapMarker {
    *                    The bit flag is expressing target pointer.
    * \param mask  [out] A bitmask for getting only flag of target pointer.
    */
-  inline void getBlockAndMask(void *addr, ptrdiff_t **block, ptrdiff_t *mask) {
+  inline void getBlockAndMask(const void *addr,
+                              ptrdiff_t **block, ptrdiff_t *mask) {
     /*
      * Calculate bitmap offset.
      * offset = (address offset from top of JavaHeap) / (pointer size)

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -254,6 +254,19 @@ OVERRIDE_DEFINE(parOld_jdk9, 3, 2)
 /* InstanceClassLoaderKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
 OVERRIDE_DEFINE(parOld_jdk9, 4, 2)
 
+/* For JDK 9 ParNew GC hook */
+
+/* InstanceKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
+OVERRIDE_DEFINE(cms_new_jdk9, 0, 2)
+/* ObjArrayKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
+OVERRIDE_DEFINE(cms_new_jdk9, 1, 2)
+/* TypeArrayKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
+OVERRIDE_DEFINE(cms_new_jdk9, 2, 2)
+/* InstanceRefKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
+OVERRIDE_DEFINE(cms_new_jdk9, 3, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
+OVERRIDE_DEFINE(cms_new_jdk9, 4, 2)
+
 
 #ifdef AVOID__i686
 /* Restore definition. */

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -267,6 +267,38 @@ OVERRIDE_DEFINE(cms_new_jdk9, 3, 2)
 /* InstanceClassLoaderKlass::oop_oop_iterate_v(oopDesc*, ExtendedOopClosure*) */
 OVERRIDE_DEFINE(cms_new_jdk9, 4, 2)
 
+/* For JDK 9 G1 GC hook */
+
+/* initial-mark */
+/* G1ParCopyClosure<(G1Barrier)0, (G1Mark)1, false>::do_oop(oopDesc**) */
+OVERRIDE_DEFINE(g1_jdk9, 0, 2)
+/* G1ParCopyClosure<(G1Barrier)0, (G1Mark)1, false>::do_oop(unsigned int*) */
+OVERRIDE_DEFINE(g1_jdk9, 1, 2)
+
+/* concurrent-root-region-scan */
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 2, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 3, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 4, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 5, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 6, 2)
+
+/* concurrent-mark / remark */
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 7, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 8, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 9, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 10, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk9, 11, 2)
+
 
 #ifdef AVOID__i686
 /* Restore definition. */

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -181,10 +181,10 @@ OVERRIDE_DEFINE(g1_6964458, 10, 2)
 
 /* CMCleanUp::do_void() */
 OVERRIDE_DEFINE_WITHOUT_PERMCHECK(g1Event, 0, 1)
-/* G1CollectedHeap::gc_prologue(bool) */
-OVERRIDE_DEFINE_WITHOUT_PERMCHECK(g1Event, 1, 2)
-/* G1CollectedHeap::gc_epilogue(bool) */
-OVERRIDE_DEFINE_WITHOUT_PERMCHECK(g1Event, 2, 2)
+/* VM_G1CollectFull::doit_prologue() */
+OVERRIDE_DEFINE_WITHOUT_PERMCHECK(g1Event, 1, 1)
+/* VM_G1CollectFull::doit_epilogue() */
+OVERRIDE_DEFINE_WITHOUT_PERMCHECK(g1Event, 2, 1)
 
 /* for Klass relocation. */
 

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -241,6 +241,19 @@ OVERRIDE_DEFINE(par_jdk9, 3, 2)
 /* InstanceClassLoaderKlass::oop_ms_adjust_pointers(oopDesc*) */
 OVERRIDE_DEFINE(par_jdk9, 4, 2)
 
+/* For JDK 9 ParallelOld GC hook */
+
+/* InstanceKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
+OVERRIDE_DEFINE(parOld_jdk9, 0, 2)
+/* ObjArrayKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
+OVERRIDE_DEFINE(parOld_jdk9, 1, 2)
+/* TypeArrayKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
+OVERRIDE_DEFINE(parOld_jdk9, 2, 2)
+/* InstanceRefKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
+OVERRIDE_DEFINE(parOld_jdk9, 3, 2)
+/* InstanceClassLoaderKlass::oop_pc_follow_contents(oopDesc*, ParCompactionManager*) */
+OVERRIDE_DEFINE(parOld_jdk9, 4, 2)
+
 
 #ifdef AVOID__i686
 /* Restore definition. */

--- a/agent/src/heapstats-engines/overrider.cpp
+++ b/agent/src/heapstats-engines/overrider.cpp
@@ -81,6 +81,7 @@ DEFINE_OVERRIDE_FUNC_5(cms_new_jdk9);
  */
 DEFINE_OVERRIDE_FUNC_9(g1);
 DEFINE_OVERRIDE_FUNC_11(g1_6964458);
+DEFINE_OVERRIDE_FUNC_12(g1_jdk9);
 
 /*!
  * \brief Override function for cleanup and System.gc() event on G1GC.
@@ -671,8 +672,59 @@ THookFunctionInfo CR8049421_g1_hook[] = {
         &callbackForIterate),
     HOOK_FUNC_END};
 
-/* TODO: We have to define valid hook for JDK 9 */
-#define jdk9_g1_hook CR8049421_g1_hook
+/*!
+ * \brief Pointer of hook information on G1GC for after JDK 9.
+ */
+THookFunctionInfo jdk9_g1_hook[] = {
+    HOOK_FUNC(
+        g1_jdk9, 0, "_ZTV16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE",
+        "_ZN16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE6do_oopEPP7oopDesc",
+        &callbackForDoOop),
+    HOOK_FUNC(
+        g1_jdk9, 1, "_ZTV16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE",
+        "_ZN16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE6do_oopEPj",
+        &callbackForDoNarrowOop),
+    HOOK_FUNC(
+        g1_jdk9, 2, "_ZTV13InstanceKlass",
+        "_ZN13InstanceKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 3, "_ZTV13ObjArrayKlass",
+        "_ZN13ObjArrayKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 4, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 5, "_ZTV16InstanceRefKlass",
+        "_ZN16InstanceRefKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 6, "_ZTV24InstanceClassLoaderKlass",
+        "_ZN24InstanceClassLoaderKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 7, "_ZTV13InstanceKlass",
+        "_ZN13InstanceKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 8, "_ZTV13ObjArrayKlass",
+        "_ZN13ObjArrayKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 9, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 10, "_ZTV16InstanceRefKlass",
+        "_ZN16InstanceRefKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk9, 11, "_ZTV24InstanceClassLoaderKlass",
+        "_ZN24InstanceClassLoaderKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC_END};
 
 /*!
  * \brief Pointer of hook information on G1GC.

--- a/agent/src/heapstats-engines/overrider.cpp
+++ b/agent/src/heapstats-engines/overrider.cpp
@@ -61,8 +61,9 @@ DEFINE_OVERRIDE_FUNC_5(par_jdk9);
  * \brief Override function for heap object on parallelOldGC.
  */
 DEFINE_OVERRIDE_FUNC_4(parOld);
-
 DEFINE_OVERRIDE_FUNC_5(parOld_6964458);
+DEFINE_OVERRIDE_FUNC_5(parOld_jdk9);
+
 /*!
  * \brief Override function for sweep at old gen on CMSGC.
  */
@@ -280,13 +281,32 @@ THookFunctionInfo CR8000213_parOld_hook[] = {
     HOOK_FUNC_END};
 
 /*!
+ * \brief Pointer of hook information on parallelOldGC for after jdk 9.
+ */
+THookFunctionInfo jdk9_parOld_hook[] = {
+    HOOK_FUNC(parOld_jdk9, 0, "_ZTV13InstanceKlass",
+              "_ZN13InstanceKlass22oop_pc_follow_contentsEP7oopDescP20ParCompactionManager",
+              &callbackForParOld),
+    HOOK_FUNC(parOld_jdk9, 1, "_ZTV13ObjArrayKlass",
+              "_ZN13ObjArrayKlass22oop_pc_follow_contentsEP7oopDescP20ParCompactionManager",
+              &callbackForParOld),
+    HOOK_FUNC(parOld_jdk9, 2, "_ZTV14TypeArrayKlass",
+              "_ZN14TypeArrayKlass22oop_pc_follow_contentsEP7oopDescP20ParCompactionManager",
+              &callbackForParOld),
+    HOOK_FUNC(parOld_jdk9, 3, "_ZTV16InstanceRefKlass",
+              "_ZN16InstanceRefKlass22oop_pc_follow_contentsEP7oopDescP20ParCompactionManager",
+              &callbackForParOld),
+    HOOK_FUNC(parOld_jdk9, 4, "_ZTV24InstanceClassLoaderKlass",
+              "_ZN24InstanceClassLoaderKlass22oop_pc_follow_contentsEP7oopDescP20ParCompactionManager",
+              &callbackForParOld),
+    HOOK_FUNC_END};
+
+/*!
  * \brief Pointers of hook information on parallelOldGC for several CRs.<br>
  *        These CRs have no impact on parallelOldGC, so refer to the last.
  */
 #define CR8027746_parOld_hook CR8000213_parOld_hook
 #define CR8049421_parOld_hook CR8000213_parOld_hook
-/* TODO: We have to define valid hook for JDK 9 */
-#define jdk9_parOld_hook CR8049421_parOld_hook
 
 /*!
  * \brief Pointer of hook information on parallelOldGC.

--- a/agent/src/heapstats-engines/overrider.cpp
+++ b/agent/src/heapstats-engines/overrider.cpp
@@ -74,6 +74,7 @@ DEFINE_OVERRIDE_FUNC_1(cms_sweep);
  */
 DEFINE_OVERRIDE_FUNC_4(cms_new);
 DEFINE_OVERRIDE_FUNC_5(cms_new_6964458);
+DEFINE_OVERRIDE_FUNC_5(cms_new_jdk9);
 
 /*!
  * \brief Override function for heap object on G1GC.
@@ -401,13 +402,33 @@ THookFunctionInfo CR8000213_cms_new_hook[] = {
     HOOK_FUNC_END};
 
 /*!
+ * \brief Pointer of hook information on CMSGC for JDK 9.
+ */
+THookFunctionInfo jdk9_cms_new_hook[] = {
+    HOOK_FUNC(cms_new_jdk9, 0, "_ZTV13InstanceKlass",
+              "_ZN13InstanceKlass17oop_oop_iterate_vEP7oopDescP18ExtendedOopClosure",
+              &callbackForIterate),
+    HOOK_FUNC(cms_new_jdk9, 1, "_ZTV13ObjArrayKlass",
+              "_ZN13ObjArrayKlass17oop_oop_iterate_vEP7oopDescP18ExtendedOopClosure",
+              &callbackForIterate),
+    HOOK_FUNC(
+        cms_new_jdk9, 2, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass17oop_oop_iterate_vEP7oopDescP18ExtendedOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(cms_new_jdk9, 3, "_ZTV16InstanceRefKlass",
+              "_ZN16InstanceRefKlass17oop_oop_iterate_vEP7oopDescP18ExtendedOopClosure",
+              &callbackForIterate),
+    HOOK_FUNC(cms_new_jdk9, 4, "_ZTV24InstanceClassLoaderKlass",
+              "_ZN24InstanceClassLoaderKlass17oop_oop_iterate_vEP7oopDescP18ExtendedOopClosure",
+              &callbackForIterate),
+    HOOK_FUNC_END};
+
+/*!
 * \brief Pointers of hook information on CMSGC for several CRs.<br>
 *        These CRs have no impact on CMSGC, so refer to the last.
 */
 #define CR8027746_cms_new_hook CR8000213_cms_new_hook
 #define CR8049421_cms_new_hook CR8000213_cms_new_hook
-/* TODO: We have to define valid hook for JDK 9 */
-#define jdk9_cms_new_hook CR8049421_cms_new_hook
 
 /*!
  * \brief Pointer of hook information on CMSGC.

--- a/agent/src/heapstats-engines/overrider.cpp
+++ b/agent/src/heapstats-engines/overrider.cpp
@@ -737,10 +737,10 @@ THookFunctionInfo *g1_hook = NULL;
 THookFunctionInfo default_g1Event_hook[] = {
     HOOK_FUNC(g1Event, 0, "_ZTV9CMCleanUp", "_ZN9CMCleanUp7do_voidEv",
               &callbackForG1Cleanup),
-    HOOK_FUNC(g1Event, 1, "_ZTV15G1CollectedHeap",
-              "_ZN15G1CollectedHeap11gc_prologueEb", &callbackForG1Full),
-    HOOK_FUNC(g1Event, 2, "_ZTV15G1CollectedHeap",
-              "_ZN15G1CollectedHeap11gc_epilogueEb", &callbackForG1FullReturn),
+    HOOK_FUNC(g1Event, 1, "_ZTV16VM_G1CollectFull",
+              "_ZN15VM_GC_Operation13doit_prologueEv", &callbackForG1Full),
+    HOOK_FUNC(g1Event, 2, "_ZTV16VM_G1CollectFull",
+              "_ZN15VM_GC_Operation13doit_epilogueEv", &callbackForG1FullReturn),
     HOOK_FUNC_END};
 
 /*!
@@ -1703,8 +1703,9 @@ void callbackForJvmtiIterate(void *oop) {
 
 /*!
  * \brief Callback function for before G1 GC cleanup.
+ * \param thisptr [in] this pointer of caller C++ instance.
  */
-void callbackForG1Cleanup(void) {
+void callbackForG1Cleanup(void *thisptr) {
   if (likely(g1FinishCallbackFunc != NULL)) {
     /* Invoke callback. */
     g1FinishCallbackFunc();
@@ -1716,16 +1717,9 @@ void callbackForG1Cleanup(void) {
 
 /*!
  * \brief Callback function for before System.gc() on using G1GC.
- * \param isFull [in] Is this event FullGC?
+ * \param thisptr [in] this pointer of caller C++ instance.
  */
-void callbackForG1Full(bool isFull) {
-  /* This function must be processed when FullGC occurs.
-   * e.g. System.gc(), evacuation failure, etc...
-   */
-  if (!isFull) {
-    return;
-  }
-
+void callbackForG1Full(void *thisptr) {
   /*
    * Disable G1 callback function:
    *  OopClosure for typeArrayKlass is called by G1 FullCollection.
@@ -1739,16 +1733,9 @@ void callbackForG1Full(bool isFull) {
 
 /*!
  * \brief Callback function for after System.gc() on using G1GC.
- * \param isFull [in] Is this event FullGC?
+ * \param thisptr [in] this pointer of caller C++ instance.
  */
-void callbackForG1FullReturn(bool isFull) {
-  /* This function must be processed when FullGC occurs.
-   * e.g. System.gc(), evacuation failure, etc...
-   */
-  if (!isFull) {
-    return;
-  }
-
+void callbackForG1FullReturn(void *thisptr) {
   /* Restore G1 callback. */
   switchOverrideFunction(g1_hook, true);
 

--- a/agent/src/heapstats-engines/overrider.hpp
+++ b/agent/src/heapstats-engines/overrider.hpp
@@ -253,9 +253,9 @@ extern "C" void callbackForAdjustPtr(void *oop);
 extern "C" void callbackForDoAddr(void *oop);
 extern "C" void callbackForUpdatePtr(void *oop);
 extern "C" void callbackForJvmtiIterate(void *oop);
-extern "C" void callbackForG1Cleanup(void);
-extern "C" void callbackForG1Full(bool isFull);
-extern "C" void callbackForG1FullReturn(bool isFull);
+extern "C" void callbackForG1Cleanup(void *thisptr);
+extern "C" void callbackForG1Full(void *thisptr);
+extern "C" void callbackForG1FullReturn(void *thisptr);
 extern "C" void callbackForInnerGCStart(void);
 extern "C" void callbackForWatcherThreadRun(void);
 

--- a/agent/src/heapstats-engines/overrider.hpp
+++ b/agent/src/heapstats-engines/overrider.hpp
@@ -158,6 +158,20 @@ typedef enum {
   DEFINE_OVERRIDE_FUNC_N(prefix, 9)     \
   DEFINE_OVERRIDE_FUNC_N(prefix, 10)
 
+#define DEFINE_OVERRIDE_FUNC_12(prefix) \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 0)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 1)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 2)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 3)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 4)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 5)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 6)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 7)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 8)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 9)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 10)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 11)
+
 /*!
  * \brief Macro to select override function with CR.
  */

--- a/agent/src/heapstats-engines/vmFunctions.cpp
+++ b/agent/src/heapstats-engines/vmFunctions.cpp
@@ -255,18 +255,20 @@ bool TVMFunctions::getFunctionsFromSymbol(void) {
  * \return Result of this function.
  */
 bool TVMFunctions::getG1VTableFromSymbol(void) {
-/* Add vtable offset */
+  /* Add vtable offset */
+  if (jvmInfo->isAfterJDK9()) {
 #ifdef __LP64__
-  VTableForTypeArrayOopClosure[0] =
+    VTableForTypeArrayOopClosure[0] =
       incAddress(symFinder->findSymbol("_ZTV14G1CMOopClosure"), 16);
-  VTableForTypeArrayOopClosure[1] =
+    VTableForTypeArrayOopClosure[1] =
       incAddress(symFinder->findSymbol("_ZTV23G1RootRegionScanClosure"), 16);
 #else
-  VTableForTypeArrayOopClosure[0] =
+    VTableForTypeArrayOopClosure[0] =
       incAddress(symFinder->findSymbol("_ZTV14G1CMOopClosure"), 8);
-  VTableForTypeArrayOopClosure[1] =
+    VTableForTypeArrayOopClosure[1] =
       incAddress(symFinder->findSymbol("_ZTV23G1RootRegionScanClosure"), 8);
 #endif
+  }
 
   if (unlikely(VTableForTypeArrayOopClosure[0] == NULL ||
                VTableForTypeArrayOopClosure[1] == NULL)) {

--- a/agent/src/heapstats-engines/vmFunctions.cpp
+++ b/agent/src/heapstats-engines/vmFunctions.cpp
@@ -33,7 +33,7 @@ void *VTableForTypeArrayOopClosure[2] __attribute__((aligned(16)));
 /*!
  * \brief Function pointer for "is_in_permanent".
  */
-THeap_IsInPermanent is_in_permanent = NULL;
+THeap_IsIn is_in_permanent = NULL;
 
 /* Internal function */
 
@@ -83,18 +83,27 @@ bool TVMFunctions::getFunctionsFromSymbol(void) {
   /* Search "is_in_permanent" function symbol. */
   if (jvmInfo->isAfterCR6964458()) {
     /* Perm gen does not exist. */
-    is_in_permanent = (THeap_IsInPermanent)&dummyIsInPermanent;
+    is_in_permanent = (THeap_IsIn)&dummyIsInPermanent;
   } else if (vmVal->getUseParallel() || vmVal->getUseParOld()) {
-    is_in_permanent = (THeap_IsInPermanent) this->symFinder->findSymbol(
+    is_in_permanent = (THeap_IsIn) this->symFinder->findSymbol(
         IS_IN_PERM_ON_PARALLEL_GC_SYMBOL);
   } else {
-    is_in_permanent = (THeap_IsInPermanent) this->symFinder->findSymbol(
+    is_in_permanent = (THeap_IsIn) this->symFinder->findSymbol(
         IS_IN_PERM_ON_OTHER_GC_SYMBOL);
   }
 
   if (unlikely(is_in_permanent == NULL)) {
     logger->printCritMsg("is_in_permanent() not found.");
     return false;
+  }
+
+  /* Search "is_in" function symbol for ParNew GC when CMS GC is worked. */
+  if (vmVal->getUseCMS()) {
+    is_in = (THeap_IsIn) this->symFinder->findSymbol(IS_IN_SYMBOL);
+    if (unlikely(is_in == NULL)) {
+      logger->printCritMsg("is_in() not found.");
+      return false;
+    }
   }
 
   /* Search "GetObjectSize" function symbol. */

--- a/agent/src/heapstats-engines/vmFunctions.hpp
+++ b/agent/src/heapstats-engines/vmFunctions.hpp
@@ -40,6 +40,11 @@
 #define IS_IN_PERM_ON_OTHER_GC_SYMBOL "_ZNK10SharedHeap15is_in_permanentEPKv"
 
 /*!
+ * \brief Symbol of Generation::is_in()
+ */
+#define IS_IN_SYMBOL "_ZNK10Generation5is_inEPKv"
+
+/*!
  * \brief Symbol of "JvmtiEnv::GetObjectSize" macro.
  */
 #ifdef __x86_64__
@@ -157,11 +162,11 @@
 /*!
  * \brief This function is C++ heap class member.<br>
  *        So 1st arg must be set instance.
- * \param thisptr [in] SharedHeap/ParallelScavengeHeap object instance.
+ * \param thisptr [in] Instance of Java memory region.
  * \param oop     [in] Java object.
- * \return Java object is existing in perm gen.
+ * \return true if oop is in this region.
  */
-typedef bool (*THeap_IsInPermanent)(void *thisptr, void *oop);
+typedef bool (*THeap_IsIn)(const void *thisptr, const void *oop);
 
 /*!
  * \brief This function is C++ JvmtiEnv class member.<br>
@@ -284,7 +289,7 @@ extern "C" void *JVM_RegisterSignal(jint sig, void *handler);
 
 /* extern variables */
 extern "C" void *VTableForTypeArrayOopClosure[2];
-extern "C" THeap_IsInPermanent is_in_permanent;
+extern "C" THeap_IsIn is_in_permanent;
 
 /*!
  * \brief This class gathers/provides functions in HotSpot VM.
@@ -295,6 +300,11 @@ class TVMFunctions {
    * \brief Function pointer for "JvmtiEnv::GetObjectSize".
    */
   TJvmtiEnv_GetObjectSize getObjectSize;
+
+  /*!
+   * \brief Function pointer for "Generation::is_in".
+   */
+  THeap_IsIn is_in;
 
   /*!
    * \brief Function pointer for "java_lang_Class::as_klassOop".
@@ -416,6 +426,10 @@ class TVMFunctions {
 
   inline int GetObjectSize(void *thisptr, jobject object, jlong *size_ptr) {
     return getObjectSize(thisptr, object, size_ptr);
+  }
+
+  inline bool IsInYoung(const void *oop) {
+    return is_in(TVMVariables::getInstance()->getYoungGen(), oop);
   }
 
   inline void *AsKlassOop(void *mirror) { return asKlassOop(mirror); }

--- a/agent/src/heapstats-engines/vmVariables.hpp
+++ b/agent/src/heapstats-engines/vmVariables.hpp
@@ -312,6 +312,21 @@ class TVMVariables {
    */
   void *threads_lock;
 
+  /*!
+   * \brief Pointer of YoungGen in GenCollectedHeap.
+   */
+  void *youngGen;
+
+  /*!
+   * \brief Start address of YoungGen.
+   */
+  void *youngGenStartAddr;
+
+  /*!
+   * \brief sizeof YoungGen.
+   */
+  size_t youngGenSize;
+
   /* Class of HeapStats for scanning variables in HotSpot VM */
   TSymbolFinder *symFinder;
   TVMStructScanner *vmScanner;
@@ -447,6 +462,9 @@ class TVMVariables {
   inline off_t getOfsOSThreadThreadId() { return ofsOSThreadThreadId; };
   inline off_t getOfsObjectMonitorObject() { return ofsObjectMonitorObject; };
   inline void *getThreadsLock() { return threads_lock; };
+  inline void *getYoungGen() const { return youngGen; };
+  inline void *getYoungGenStartAddr() const { return youngGenStartAddr; };
+  inline size_t getYoungGenSize() const { return youngGenSize; };
 };
 
 #endif  // VMVARIABLES_H

--- a/agent/test/snapshot/testcase.sh
+++ b/agent/test/snapshot/testcase.sh
@@ -14,9 +14,9 @@ fi
 
 # Check1: Parallel
 echo "Check1-1: Parallel"
-$JAVA_HOME/bin/java -agentpath:$TARGET_HEAPSTATS $JAVA_OPTS Simple
+$JAVA_HOME/bin/java -agentpath:$TARGET_HEAPSTATS $JAVA_OPTS -XX:+UseParallelGC -XX:-UseParallelOldGC Simple
 echo "Check1-2: Parallel (-UseCOOP)"
-$JAVA_HOME/bin/java -agentpath:$TARGET_HEAPSTATS $JAVA_OPTS -XX:-UseCompressedOops Simple
+$JAVA_HOME/bin/java -agentpath:$TARGET_HEAPSTATS $JAVA_OPTS -XX:+UseParallelGC -XX:-UseParallelOldGC -XX:-UseCompressedOops Simple
 
 # Check2: ParallelOld
 echo "Check2-1: ParallelOld"


### PR DESCRIPTION
This PR adds ParallelOld/CMS/G1 hook for JDK 9.
If these changes are merged, we can run HeapStats agent on JDK 9 EA b119.
