### PR TITLE
Bug 3023: [JDK 9] Search JDK shared-library correctly

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2016-06-16  KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3023: [JDK 9] Search JDK shared-library correctly
+
 2016-06-02  Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 2970: [JDK 9] Add ParallelOldGC hook for JDK 9

--- a/configure
+++ b/configure
@@ -8142,9 +8142,7 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for JDK library using found JAVA_HOME" >&5
 $as_echo_n "checking for JDK library using found JAVA_HOME... " >&6; }
 if test -z "$JDK_DIR" || test ! -d $JDK_DIR || test ! -r $JDK_DIR \
-  || test ! -d $JDK_DIR/bin/ || test ! -r $JDK_DIR/bin/ \
-  || test ! -d $JDK_DIR/include/ || test ! -r $JDK_DIR/include/ \
-  || test ! -d $JDK_DIR/lib/ || test ! -r $JDK_DIR/lib/ ; then
+  || test ! -d $JDK_DIR/bin/ || test ! -x $JDK_DIR/bin/javac ; then
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
 $as_echo "not found" >&6; }

--- a/configure
+++ b/configure
@@ -8144,7 +8144,6 @@ $as_echo_n "checking for JDK library using found JAVA_HOME... " >&6; }
 if test -z "$JDK_DIR" || test ! -d $JDK_DIR || test ! -r $JDK_DIR \
   || test ! -d $JDK_DIR/bin/ || test ! -r $JDK_DIR/bin/ \
   || test ! -d $JDK_DIR/include/ || test ! -r $JDK_DIR/include/ \
-  || test ! -d $JDK_DIR/jre/ || test ! -r $JDK_DIR/jre/ \
   || test ! -d $JDK_DIR/lib/ || test ! -r $JDK_DIR/lib/ ; then
 
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: not found" >&5
@@ -8185,6 +8184,10 @@ $as_echo_n "checking for of VMStructs in jvm shared-library... " >&6; }
   do
     if test -d $JDK_DIR/jre/lib/$archPath/ ; then
       JVM_LIB_DIR=`$ECHO $JDK_DIR/jre/lib/$archPath 2>$DEVNULL`
+      break
+    elif test -d $JDK_DIR/lib/$archPath/ ; then
+      # JDK9 does not have jre directory
+      JVM_LIB_DIR=`$ECHO $JDK_DIR/lib/$archPath 2>$DEVNULL`
       break
     fi
   done

--- a/configure.ac
+++ b/configure.ac
@@ -228,10 +228,8 @@ fi
 
 AC_MSG_CHECKING([for JDK library using found JAVA_HOME])
 if test -z "$JDK_DIR" || test ! -d $JDK_DIR || test ! -r $JDK_DIR \
-  || test ! -d $JDK_DIR/bin/ || test ! -r $JDK_DIR/bin/ \
-  || test ! -d $JDK_DIR/include/ || test ! -r $JDK_DIR/include/ \
-  || test ! -d $JDK_DIR/lib/ || test ! -r $JDK_DIR/lib/ ; then
-  
+  || test ! -d $JDK_DIR/bin/ || test ! -x $JDK_DIR/bin/javac ; then
+
   AC_MSG_RESULT([not found])
   AC_MSG_NOTICE([
     [Do you put java at non default directory ?]

--- a/configure.ac
+++ b/configure.ac
@@ -230,7 +230,6 @@ AC_MSG_CHECKING([for JDK library using found JAVA_HOME])
 if test -z "$JDK_DIR" || test ! -d $JDK_DIR || test ! -r $JDK_DIR \
   || test ! -d $JDK_DIR/bin/ || test ! -r $JDK_DIR/bin/ \
   || test ! -d $JDK_DIR/include/ || test ! -r $JDK_DIR/include/ \
-  || test ! -d $JDK_DIR/jre/ || test ! -r $JDK_DIR/jre/ \
   || test ! -d $JDK_DIR/lib/ || test ! -r $JDK_DIR/lib/ ; then
   
   AC_MSG_RESULT([not found])
@@ -262,6 +261,10 @@ if test "$enable_vmstructs" = "yes" ; then
   do
     if test -d $JDK_DIR/jre/lib/$archPath/ ; then
       JVM_LIB_DIR=`$ECHO $JDK_DIR/jre/lib/$archPath 2>$DEVNULL`
+      break
+    elif test -d $JDK_DIR/lib/$archPath/ ; then
+      # JDK9 does not have jre directory
+      JVM_LIB_DIR=`$ECHO $JDK_DIR/lib/$archPath 2>$DEVNULL`
       break
     fi
   done


### PR DESCRIPTION
jdk9 changes directory layout due to [JEP220: Modular Run-Time Images](http://openjdk.java.net/jeps/220).
We must change to search JDK shared-library arch directory correctly for building HeapStats agent by JDK9.
