### PR TITLE
Bug 3057: [JDK 9] HeapStats Analyzer could not start on JDK 9

### DIFF
--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/ArchiveDataConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/ArchiveDataConverter.java
@@ -32,8 +32,7 @@ public class ArchiveDataConverter extends StringConverter<ArchiveData>{
 
     @Override
     public String toString(ArchiveData object) {
-        LocalDateTimeConverter dateTimeConv = new LocalDateTimeConverter();
-        return dateTimeConv.toString(object.getDate());
+        return (object == null) ? null : (new LocalDateTimeConverter()).toString(object.getDate());
     }
 
     @Override

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/LogDataConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/LogDataConverter.java
@@ -32,7 +32,7 @@ public class LogDataConverter extends StringConverter<LogData> {
     @Override
     public String toString(LogData object) {
         LocalDateTimeConverter dateTimeConv = new LocalDateTimeConverter();
-        return dateTimeConv.toString(object.getDateTime());
+        return (object == null) ? null : (new LocalDateTimeConverter()).toString(object.getDateTime());
     }
 
     /**

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/LocalDateTimeConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/LocalDateTimeConverter.java
@@ -38,12 +38,12 @@ public class LocalDateTimeConverter extends StringConverter<LocalDateTime>{
     
     @Override
     public String toString(LocalDateTime object) {
-        return formatter.format(object);
+        return (object == null) ? null : formatter.format(object);
     }
 
     @Override
     public LocalDateTime fromString(String string) {
-        return LocalDateTime.parse(string, formatter);
+        return (string == null) ? null : LocalDateTime.parse(string, formatter);
     }
     
 }

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/ThreadStatConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/ThreadStatConverter.java
@@ -30,8 +30,7 @@ public class ThreadStatConverter extends StringConverter<ThreadStat>{
 
     @Override
     public String toString(ThreadStat object) {
-        LocalDateTimeConverter converter = new LocalDateTimeConverter();
-        return converter.toString(object.getTime());
+        return (object == null) ? null : (new LocalDateTimeConverter()).toString(object.getTime());
     }
 
     @Override


### PR DESCRIPTION
This PR is [Bug 3057](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3057) .
Please review.
