### PR TITLE
Bug 3167: Fix incorrect message caused by class unloading in CMS.

### DIFF
--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -194,7 +194,7 @@ TObjectData *TClassContainer::pushNewClass(void *klassOop) {
   /* If failure getting class name. */
   if (unlikely(cur->className == NULL)) {
     /* Adding empty to list is deny. */
-    logger->printWarnMsg("Couldn't allocate counter memory!");
+    logger->printWarnMsg("Couldn't get class name!");
     free(cur);
     return NULL;
   }

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -99,7 +99,7 @@ OVERRIDE_DEFINE(parOld_6964458, 4, 3)
  */
 
 /* SweepClosure::do_blk_careful(HeapWord*) */
-OVERRIDE_DEFINE_WITHOUT_PERMCHECK(cms_sweep, 0, 2)
+OVERRIDE_DEFINE(cms_sweep, 0, 2)
 
 /* instanceKlass::oop_oop_iterate_nv(oopDesc*, Par_MarkRefsIntoAndScanClosure*) */
 OVERRIDE_DEFINE(cms_new, 0, 2)


### PR DESCRIPTION
This PR is for [Bug 3167](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3167).
Please review.
