### PR TITLE
Bug 3000: Color of enabled exclude filter is difficult to understand

### DIFF
--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -175,7 +175,7 @@ public class HistogramController implements Initializable {
                 BindingFilter filter = (BindingFilter)getTableRow().getItem();
                 
                 if(!empty && (filter != null)){
-                    styleProperty().bind(Bindings.createStringBinding(() -> filter.appliedProperty().get() ? "-fx-text-fill: blue;" : "-fx-text-fill: black;", filter.appliedProperty()));
+                    styleProperty().bind(Bindings.createStringBinding(() -> filter.appliedProperty().get() ? "-fx-background-color: skyblue;" : "-fx-background-color: white;", filter.appliedProperty()));
                     setText(filter.getName());
                 }
 


### PR DESCRIPTION
This PR is for [Bug 3000](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3000) .
I attached the image after applying this patch.

![bug3000-fix](https://cloud.githubusercontent.com/assets/7421132/19117094/d44f07d2-8b52-11e6-9049-c1fcb5e8d8aa.png)
