### PR TITLE
Bug 3191: Enable to change font size of Reference Tree by config

### DIFF
--- a/analyzer/fx/heapstats.properties
+++ b/analyzer/fx/heapstats.properties
@@ -12,3 +12,4 @@ heaporder_bottom_young=true
 language=en
 datetime_format=yyyy/MM/dd HH:mm:ss
 #plugins=
+reftree_fontsize=11

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/RefTreeController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/RefTreeController.java
@@ -159,6 +159,7 @@ public class RefTreeController implements Initializable, MouseListener {
     @Override
     public void initialize(URL url, ResourceBundle rb) {
         resource = rb;
+        ReferenceCell.initialize();
         currentSnapShotHeader = new SimpleObjectProperty<>();
         currentObjectTag = new SimpleLongProperty();
         currentObjectTag.addListener((v, o, n) -> Optional.ofNullable(n).ifPresent(t -> buildTab()));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceCell.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceCell.java
@@ -2,7 +2,7 @@
  * ReferenceCell.java
  * Created on 2012/11/18
  *
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,7 +24,9 @@ package jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.tabs;
 import java.text.NumberFormat;
 import com.mxgraph.model.mxCell;
 import com.mxgraph.model.mxGeometry;
+import com.mxgraph.util.mxConstants;
 import jp.co.ntt.oss.heapstats.container.snapshot.ObjectData;
+import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
 
 /**
  * extends {@link mxCell}<br>
@@ -39,14 +41,25 @@ public class ReferenceCell extends mxCell {
     private static final long serialVersionUID = -4403355352725440764L;
 
     /**
+     * Defines the font size
+     */
+    private static final String FONT_SIZE =
+        String.valueOf(HeapStatsUtils.getFontSizeOfRefTree());
+    /**
+     * Defines the zoom ratio by font size ratio.
+     */
+    private static final double ZOOM_RATIO =
+      (double) HeapStatsUtils.getFontSizeOfRefTree() / mxConstants.DEFAULT_FONTSIZE;
+
+    /**
      * Defines the height of the cell.
      */
-    private static final int CELL_HEIGHT = 30;
+    private static final int CELL_HEIGHT = (int)(30 * ZOOM_RATIO);
 
     /**
      * Define the width of the character in the cell.
      */
-    private static final int CHAR_WIDTH = 6;
+    private static final int CHAR_WIDTH = (int)(7 * ZOOM_RATIO);
 
     /**
      * Information about the objects to display Map.
@@ -76,9 +89,10 @@ public class ReferenceCell extends mxCell {
             setValue(data.getName());
             setConnectable(false);
             setVertex(true);
+            setStyle("fontSize="+FONT_SIZE);
 
             if (root) {
-                setStyle("shape=ellipse;fillColor=red;fontColor=black");
+                setStyle("shape=ellipse;fillColor=red;fontColor=black;fontSize="+FONT_SIZE);
             }
 
             rootCell = root;

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceCell.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceCell.java
@@ -43,23 +43,21 @@ public class ReferenceCell extends mxCell {
     /**
      * Defines the font size
      */
-    private static final String FONT_SIZE =
-        String.valueOf(HeapStatsUtils.getFontSizeOfRefTree());
+    private static String FONT_SIZE;
     /**
      * Defines the zoom ratio by font size ratio.
      */
-    private static final double ZOOM_RATIO =
-      (double) HeapStatsUtils.getFontSizeOfRefTree() / mxConstants.DEFAULT_FONTSIZE;
+    private static double ZOOM_RATIO;
 
     /**
      * Defines the height of the cell.
      */
-    private static final int CELL_HEIGHT = (int)(30 * ZOOM_RATIO);
+    private static int CELL_HEIGHT;
 
     /**
      * Define the width of the character in the cell.
      */
-    private static final int CHAR_WIDTH = (int)(7 * ZOOM_RATIO);
+    private static int CHAR_WIDTH;
 
     /**
      * Information about the objects to display Map.
@@ -101,6 +99,17 @@ public class ReferenceCell extends mxCell {
         setConnectable(false);
         setGeometry(new mxGeometry(0, 0, CHAR_WIDTH * data.getName().length(), CELL_HEIGHT));
     }
+
+    /**
+     * Initialize to define the size.
+     */
+    public static void initialize() {
+        FONT_SIZE = String.valueOf(HeapStatsUtils.getFontSizeOfRefTree());
+        ZOOM_RATIO = (double) HeapStatsUtils.getFontSizeOfRefTree() / mxConstants.DEFAULT_FONTSIZE;
+        CELL_HEIGHT = (int)(30 * ZOOM_RATIO);
+        CHAR_WIDTH = (int)(7 * ZOOM_RATIO);
+    }
+
 
     /**
      * Return the tag.

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceGraph.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/ReferenceGraph.java
@@ -2,7 +2,7 @@
  * ReferenceGraph.java
  * Created on 2012/11/18
  *
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -27,6 +27,7 @@ import java.util.Map;
 import com.mxgraph.util.mxConstants;
 import com.mxgraph.view.mxGraph;
 import com.mxgraph.view.mxStylesheet;
+import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
 
 /**
  * extends {@link mxGraph}<br>
@@ -56,6 +57,7 @@ public class ReferenceGraph extends mxGraph {
         edgeStyle.put(mxConstants.STYLE_STROKECOLOR, "#000000");
         edgeStyle.put(mxConstants.STYLE_FONTCOLOR, "#000000");
         edgeStyle.put(mxConstants.STYLE_ALIGN, mxConstants.ALIGN_RIGHT);
+        edgeStyle.put(mxConstants.STYLE_FONTSIZE, HeapStatsUtils.getFontSizeOfRefTree());
 
         mxStylesheet style = new mxStylesheet();
         style.setDefaultEdgeStyle(edgeStyle);

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -177,6 +177,12 @@ public class HeapStatsUtils {
         prop.putIfAbsent("datetime_format", "yyyy/MM/dd HH:mm:ss");
         formatter = DateTimeFormatter.ofPattern(prop.getProperty("datetime_format"));
 
+        /* Font size of RefTree */
+        String fontsize = prop.getProperty("reftree_fontsize");
+        if (fontsize == null) {
+            prop.setProperty("reftree_fontsize", "11");
+        }
+
         /* Add shutdown hook for saving current settings. */
         Runnable savePropImpl = () -> {
             try (OutputStream out = Files.newOutputStream(properties, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
@@ -309,6 +315,22 @@ public class HeapStatsUtils {
      */
     public static DateTimeFormatter getDateTimeFormatter(){
         return formatter;
+    }
+
+    /**
+     * Get font size of ReferenceTree tab.
+     * @return fontSize
+     */
+    public static int getFontSizeOfRefTree() {
+        return Integer.parseInt(prop.getProperty("reftree_fontsize"));
+    }
+
+    /**
+     * Get font size of ReferenceTree tab.
+     * @param fontSize font size
+     */
+    public static void setFontSizeOfRefTree( int fontSize ) {
+        prop.setProperty("reftree_fontsize", Integer.toString(fontSize));
     }
 
     /**


### PR DESCRIPTION
This change will enable to change a font size of Reference Tree Tab by a new property "reftree_fontsize".

reftree_fontsize=20
![reftree_fontsize=20](https://cloud.githubusercontent.com/assets/489607/19161783/294ddc08-8c30-11e6-8b5a-e59fed30bbdb.png)
reftree_fontsize=30
![reftree_fontsize=30](https://cloud.githubusercontent.com/assets/489607/19161791/349bdc9a-8c30-11e6-866d-c40573cf4dec.png)

icedtea bugzilla: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3191
