### PR TITLE
Bug3001: HeapStats CLI should report error without exception

### DIFF
--- a/analyzer/cli/src/main/java/jp/co/ntt/oss/heapstats/cli/CliMain.java
+++ b/analyzer/cli/src/main/java/jp/co/ntt/oss/heapstats/cli/CliMain.java
@@ -17,6 +17,7 @@
  */
 package jp.co.ntt.oss.heapstats.cli;
 
+import java.util.Optional;
 import jp.co.ntt.oss.heapstats.cli.processor.CliProcessor;
 import jp.co.ntt.oss.heapstats.cli.processor.JMXProcessor;
 import jp.co.ntt.oss.heapstats.cli.processor.LogProcessor;
@@ -76,11 +77,8 @@ public class CliMain implements Thread.UncaughtExceptionHandler{
             rootCause = rootCause.getCause();
         }
         
-        String message = rootCause.getLocalizedMessage();
-        if(message == null){
-            message = rootCause.toString();
-        }
-        
+        String message = Optional.ofNullable(rootCause.getLocalizedMessage())
+                                 .orElse(rootCause.toString());        
         System.err.println("HeapStats CLI error: " + message);
         if(Boolean.getBoolean("debug")){
             thrwbl.printStackTrace();

--- a/analyzer/cli/src/main/java/jp/co/ntt/oss/heapstats/cli/CliMain.java
+++ b/analyzer/cli/src/main/java/jp/co/ntt/oss/heapstats/cli/CliMain.java
@@ -38,7 +38,13 @@ public class CliMain implements Thread.UncaughtExceptionHandler{
         Options options = new Options();
         Thread.setDefaultUncaughtExceptionHandler(new CliMain());
         
-        options.parse(args);
+        try{
+            options.parse(args);
+        }
+        catch(Exception e){
+            options.printHelp();
+            System.exit(1);
+        }
         
         CliProcessor processor;
         Options.FileType fileType = options.getType();
@@ -72,7 +78,8 @@ public class CliMain implements Thread.UncaughtExceptionHandler{
     public void uncaughtException(Thread thread, Throwable thrwbl) {
         Throwable rootCause = thrwbl;
         
-        // Find root cause of exception
+        // Find root cause of exception.
+        // Exceptions is recuesive. So we need to track exception(s) through Throwable#getCause().
         while(rootCause.getCause() != null){
             rootCause = rootCause.getCause();
         }


### PR DESCRIPTION
This PR is for [Bug 3001](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3001) .

IMHO, it is difficult to catch all `Throwable` patterns. For example, to catch `OutOfMemoryError` is very difficult. 
So I propose to use uncaught exception handler. I've implemented to find root cause and to show localized message of it.
If you want to see stack trace for debugging, you can add `-Ddebug` to arguments of java.

Comments is appreciated.
Please review it.
