### PR TITLE
Bug 3194: Time-Awareness XAxis in FXAnalyzer

### DIFF
--- a/analyzer/fx/heapstats.properties
+++ b/analyzer/fx/heapstats.properties
@@ -14,3 +14,4 @@ datetime_format=yyyy/MM/dd HH:mm:ss
 #plugins=
 reftree_fontsize=11
 tickmarker=false
+x_tickunit=20

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
@@ -471,10 +471,12 @@ public class LogResourcesController implements Initializable {
             long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(javaMemoryChart, threadChart)
                   .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / 100.0d))
                   .peek(a -> a.setLowerBound(startLogEpoch))
                   .forEach(a -> a.setUpperBound(endLogEpoch));
             Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
                   .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / 100.0d))
                   .peek(a -> a.setLowerBound(startDiffEpoch))
                   .forEach(a -> a.setUpperBound(endDiffEpoch));
             

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
@@ -471,12 +471,12 @@ public class LogResourcesController implements Initializable {
             long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(javaMemoryChart, threadChart)
                   .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / 100.0d))
+                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(a -> a.setLowerBound(startLogEpoch))
                   .forEach(a -> a.setUpperBound(endLogEpoch));
             Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
                   .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / 100.0d))
+                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(a -> a.setLowerBound(startDiffEpoch))
                   .forEach(a -> a.setUpperBound(endDiffEpoch));
             

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/SnapShotController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/SnapShotController.java
@@ -20,6 +20,7 @@ package jp.co.ntt.oss.heapstats.plugin.builtin.snapshot;
 import java.io.File;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +49,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
-import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -375,7 +376,7 @@ public class SnapShotController extends PluginController implements Initializabl
         parseThread.start();
     }
 
-    private void drawRebootSuspectLine(XYChart<String, ? extends Number> target) {
+    private void drawRebootSuspectLine(XYChart<Number, ? extends Number> target) {
 
         if (target.getData().isEmpty() || target.getData().get(0).getData().isEmpty()) {
             return;
@@ -389,18 +390,18 @@ public class SnapShotController extends PluginController implements Initializabl
         ObservableList<Node> anchorChildren = anchor.getChildren();
         anchorChildren.clear();
 
-        CategoryAxis xAxis = (CategoryAxis) target.getXAxis();
+        NumberAxis xAxis = (NumberAxis)target.getXAxis();
         Axis yAxis = target.getYAxis();
         Label chartTitle = (Label) target.getChildrenUnmodifiable().stream()
                 .filter(n -> n.getStyleClass().contains("chart-title"))
                 .findFirst()
                 .get();
 
-        double startX = xAxis.getLayoutX() + xAxis.getStartMargin() - 1.0d;
+        double startX = xAxis.getLayoutX() + 4.0d;
         double yPos = yAxis.getLayoutY() + chartTitle.getLayoutY() + chartTitle.getHeight();
         List<Rectangle> rectList = summaryData.get().getRebootSuspectList()
                 .stream()
-                .map(d -> d.format(HeapStatsUtils.getDateTimeFormatter()))
+                .map(d -> d.atZone(ZoneId.systemDefault()).toEpochSecond())
                 .map(s -> new Rectangle(xAxis.getDisplayPosition(s) + startX, yPos, 4d, yAxis.getHeight()))
                 .peek(r -> ((Rectangle) r).setStyle("-fx-fill: yellow;"))
                 .collect(Collectors.toList());

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -20,6 +20,7 @@ package jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.tabs;
 import java.io.File;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -103,7 +104,7 @@ public class HistogramController implements Initializable {
     private Button selectFilterApplyBtn;
 
     @FXML
-    private StackedAreaChart<String, Long> topNChart;
+    private StackedAreaChart<Number, Long> topNChart;
 
     @FXML
     private AnchorPane topNChartAnchor;
@@ -145,7 +146,7 @@ public class HistogramController implements Initializable {
 
     private LongProperty currentObjectTag;
 
-    private Consumer<XYChart<String, ? extends Number>> drawRebootSuspectLine;
+    private Consumer<XYChart<Number, ? extends Number>> drawRebootSuspectLine;
 
     private Consumer<Task<Void>> taskExecutor;
 
@@ -223,8 +224,8 @@ public class HistogramController implements Initializable {
      * chart series as value.
      * @param objData ObjectData which is you want to build.
      */
-    private void buildTopNChartData(SnapShotHeader header, Map<String, XYChart.Series<String, Long>> seriesMap, ObjectData objData) {
-        XYChart.Series<String, Long> series = seriesMap.get(objData.getName());
+    private void buildTopNChartData(SnapShotHeader header, Map<String, XYChart.Series<Number, Long>> seriesMap, ObjectData objData) {
+        XYChart.Series<Number, Long> series = seriesMap.get(objData.getName());
 
         if (series == null) {
             series = new XYChart.Series<>();
@@ -233,10 +234,10 @@ public class HistogramController implements Initializable {
             seriesMap.put(objData.getName(), series);
         }
 
-        String time = header.getSnapShotDate().format(HeapStatsUtils.getDateTimeFormatter());
+        long time = header.getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long yValue = instanceGraph.get() ? objData.getCount()
                 : objData.getTotalSize() / 1024 / 1024;
-        XYChart.Data<String, Long> data = new XYChart.Data<>(time, yValue);
+        XYChart.Data<Number, Long> data = new XYChart.Data<>(time, yValue);
 
         series.getData().add(data);
         String unit = instanceGraph.get() ? "instances" : "MB";
@@ -244,7 +245,7 @@ public class HistogramController implements Initializable {
         Tooltip.install(data.getNode(), new Tooltip(tip));
     }
 
-    private void setTopNChartColor(XYChart.Series<String, Long> series) {
+    private void setTopNChartColor(XYChart.Series<Number, Long> series) {
         String color = ChartColorManager.getNextColor(series.getName());
 
         series.getNode().lookup(".chart-series-area-line").setStyle(String.format("-fx-stroke: %s;", color));
@@ -262,7 +263,14 @@ public class HistogramController implements Initializable {
      * @param seriesMap Chart series map which is contains class name as key,
      * chart series as value.
      */
-    private void onDiffTaskSucceeded(DiffCalculator diff, Map<String, XYChart.Series<String, Long>> seriesMap) {
+    private void onDiffTaskSucceeded(DiffCalculator diff, Map<String, XYChart.Series<Number, Long>> seriesMap) {
+        /* Set chart range */
+        long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
+        long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
+        NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
+        xAxis.setLowerBound(startEpoch);
+        xAxis.setUpperBound(endEpoch);
+        
         topNList.set(FXCollections.observableMap(diff.getTopNList()));
 
         currentTarget.get().stream()
@@ -442,7 +450,7 @@ public class HistogramController implements Initializable {
     public Task<Void> getDrawTopNDataTask(List<SnapShotHeader> target, boolean includeOthers, Predicate<? super ObjectData> predicate) {
         topNChart.getData().clear();
         lastDiffTable.getItems().clear();
-        Map<String, XYChart.Series<String, Long>> seriesMap = new HashMap<>();
+        Map<String, XYChart.Series<Number, Long>> seriesMap = new HashMap<>();
 
         TaskAdapter<DiffCalculator> diff = new TaskAdapter<>(new DiffCalculator(target, HeapStatsUtils.getRankLevel(),
                 includeOthers, predicate, HeapStatsUtils.getReplaceClassName(), instanceGraph.get()));
@@ -456,7 +464,7 @@ public class HistogramController implements Initializable {
      *
      * @param drawRebootSuspectLine Consumer for drawing reboot line.
      */
-    public void setDrawRebootSuspectLine(Consumer<XYChart<String, ? extends Number>> drawRebootSuspectLine) {
+    public void setDrawRebootSuspectLine(Consumer<XYChart<Number, ? extends Number>> drawRebootSuspectLine) {
         this.drawRebootSuspectLine = drawRebootSuspectLine;
     }
 
@@ -512,7 +520,7 @@ public class HistogramController implements Initializable {
      *
      * @return TopN chart.
      */
-    public StackedAreaChart<String, Long> getTopNChart() {
+    public StackedAreaChart<Number, Long> getTopNChart() {
         return topNChart;
     }
 

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -269,7 +269,7 @@ public class HistogramController implements Initializable {
         long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
-        xAxis.setTickUnit((endEpoch - startEpoch) / 100.0d);
+        xAxis.setTickUnit((endEpoch - startEpoch) / HeapStatsUtils.getXTickUnit());
         xAxis.setLowerBound(startEpoch);
         xAxis.setUpperBound(endEpoch);
         

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -269,6 +269,7 @@ public class HistogramController implements Initializable {
         long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
+        xAxis.setTickUnit((endEpoch - startEpoch) / 100.0d);
         xAxis.setLowerBound(startEpoch);
         xAxis.setUpperBound(endEpoch);
         

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
@@ -262,6 +262,7 @@ public class SummaryController implements Initializable {
             long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(heapChart, instanceChart, gcTimeChart, metaspaceChart)
+                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / 100.0d))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setLowerBound(startEpoch))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setUpperBound(endEpoch))
                   .forEach(c -> Platform.runLater(() -> drawRebootSuspectLine.accept(c)));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
@@ -262,7 +262,7 @@ public class SummaryController implements Initializable {
             long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(heapChart, instanceChart, gcTimeChart, metaspaceChart)
-                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / 100.0d))
+                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setLowerBound(startEpoch))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setUpperBound(endEpoch))
                   .forEach(c -> Platform.runLater(() -> drawRebootSuspectLine.accept(c)));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/EpochTimeConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/EpochTimeConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package jp.co.ntt.oss.heapstats.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import javafx.util.StringConverter;
+
+/**
+ * String converter for epoch time.
+ * This class supports SECOND time unit ONLY.
+ * 
+ * @author Yasumasa Suenaga
+ */
+public class EpochTimeConverter extends StringConverter<Number>{
+
+    @Override
+    public String toString(Number object) {
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(object.longValue()), ZoneId.systemDefault()).format(HeapStatsUtils.getDateTimeFormatter());
+    }
+
+    @Override
+    public Number fromString(String string) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+}

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -188,6 +188,18 @@ public class HeapStatsUtils {
             prop.setProperty("tickmarker", "false");
         }
 
+        /* TickUnit of X axis */
+        String xTickUnitStr = prop.getProperty("x_tickunit");
+        if (xTickUnitStr == null) {
+            prop.setProperty("x_tickunit", "20");
+        } else {
+            try {
+                Double.parseDouble(xTickUnitStr);
+            } catch (NumberFormatException e) {
+                throw new HeapStatsConfigException(resource.getString("invalid.option") + " x_tickunit=" + xTickUnitStr, e);
+            }
+        }
+
         /* Add shutdown hook for saving current settings. */
         Runnable savePropImpl = () -> {
             try (OutputStream out = Files.newOutputStream(properties, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
@@ -345,6 +357,15 @@ public class HeapStatsUtils {
      */
     public static boolean getTickMarkerSwitch() {
         return Boolean.parseBoolean(prop.getProperty("tickmarker"));
+    }
+    
+    /**
+     * Get TickUnit on X axis.
+     * 
+     * @return TickUnit of X axis.
+     */
+    public static double getXTickUnit(){
+        return Double.parseDouble(prop.getProperty("x_tickunit"));
     }
     
     /**

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
@@ -41,7 +41,7 @@
                     <children>
                         <LineChart id="threadChart" fx:id="threadChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.thread">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />
@@ -63,7 +63,7 @@
                     <children>
                         <StackedAreaChart id="javaCPUChart" fx:id="javaCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.javacpu">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
@@ -76,7 +76,7 @@
                     <children>
                         <StackedAreaChart id="systemCPUChart" fx:id="systemCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.systemcpu">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
@@ -89,7 +89,7 @@
                     <children>
                         <LineChart id="javaMemoryChart" fx:id="javaMemoryChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.nativememory">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />
@@ -102,7 +102,7 @@
                     <children>
                         <LineChart id="safepointChart" fx:id="safepointChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.count">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />
@@ -115,7 +115,7 @@
                     <children>
                         <LineChart id="safepointTimeChart" fx:id="safepointTimeChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.time">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="ms" side="LEFT" minorTickVisible="false" />
@@ -128,7 +128,7 @@
                     <children>
                         <LineChart id="monitorChart" fx:id="monitorChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.monitorcontention">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -41,7 +41,7 @@
                     <children>
                         <LineChart id="threadChart" fx:id="threadChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.thread">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />
@@ -63,7 +63,7 @@
                     <children>
                         <StackedAreaChart id="javaCPUChart" fx:id="javaCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.javacpu">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" tickUnit="10.0" upperBound="100.0d" />
@@ -76,7 +76,7 @@
                     <children>
                         <StackedAreaChart id="systemCPUChart" fx:id="systemCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.systemcpu">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" tickUnit="10.0" upperBound="100.0d" />
@@ -89,7 +89,7 @@
                     <children>
                         <LineChart id="javaMemoryChart" fx:id="javaMemoryChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.nativememory">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="MB" side="LEFT" />
@@ -102,7 +102,7 @@
                     <children>
                         <LineChart id="safepointChart" fx:id="safepointChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.count">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />
@@ -115,7 +115,7 @@
                     <children>
                         <LineChart id="safepointTimeChart" fx:id="safepointTimeChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.time">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="ms" side="LEFT" />
@@ -128,7 +128,7 @@
                     <children>
                         <LineChart id="monitorChart" fx:id="monitorChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.monitorcontention">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -66,7 +66,7 @@
                             <children>
                                 <StackedAreaChart fx:id="topNChart" animated="false" legendVisible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis fx:id="topNYAxis" autoRanging="false" label="MB" side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
@@ -66,7 +66,7 @@
                             <children>
                                 <StackedAreaChart fx:id="topNChart" animated="false" legendVisible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis fx:id="topNYAxis" autoRanging="false" label="MB" side="LEFT" minorTickVisible="false" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -46,7 +46,7 @@
                             <children>
                                 <StackedAreaChart id="heapChart" fx:id="heapChart" animated="false" createSymbols="false" layoutX="-129.0" layoutY="-91.0" minHeight="0.0" title="%chart.javaheap" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" />
@@ -59,7 +59,7 @@
                             <children>
                                 <LineChart id="instanceChart" fx:id="instanceChart" animated="false" createSymbols="false" layoutX="-149.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.instances" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" visible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" visible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="instances" side="LEFT" />
@@ -72,7 +72,7 @@
                             <children>
                                 <LineChart id="gcTimeChart" fx:id="gcTimeChart" animated="false" createSymbols="false" layoutX="-169.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.gctime" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="ms" side="LEFT" />
@@ -85,7 +85,7 @@
                             <children>
                                 <AreaChart id="metaspaceChart" fx:id="metaspaceChart" animated="false" createSymbols="false" layoutX="-174.0" layoutY="-166.0" minHeight="0.0" title="%chart.metaspace" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
@@ -46,7 +46,7 @@
                             <children>
                                 <StackedAreaChart id="heapChart" fx:id="heapChart" animated="false" createSymbols="false" layoutX="-129.0" layoutY="-91.0" minHeight="0.0" title="%chart.javaheap" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />
@@ -59,7 +59,7 @@
                             <children>
                                 <LineChart id="instanceChart" fx:id="instanceChart" animated="false" createSymbols="false" layoutX="-149.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.instances" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" visible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="instances" side="LEFT" minorTickVisible="false" />
@@ -72,7 +72,7 @@
                             <children>
                                 <LineChart id="gcTimeChart" fx:id="gcTimeChart" animated="false" createSymbols="false" layoutX="-169.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.gctime" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="ms" side="LEFT" minorTickVisible="false" />
@@ -85,7 +85,7 @@
                             <children>
                                 <AreaChart id="metaspaceChart" fx:id="metaspaceChart" animated="false" createSymbols="false" layoutX="-174.0" layoutY="-166.0" minHeight="0.0" title="%chart.metaspace" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />


### PR DESCRIPTION
This PR is for [Bug 3194](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3194) .
Currently, all SnapShot data is drawn same distance:

![before](https://cloud.githubusercontent.com/assets/7421132/19220849/dc3d6f48-8e71-11e6-95a1-0df5e532931a.png)

After applying this patch, HeapStats user can be aware of time series:

![after](https://cloud.githubusercontent.com/assets/7421132/19220850/fa2f48fa-8e71-11e6-92b6-3082e49f0458.png)

Please review!
