### PR TITLE
Bug 3197: Add a validation of reftree_fontsize

### DIFF
--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -181,8 +181,14 @@ public class HeapStatsUtils {
         String fontsize = prop.getProperty("reftree_fontsize");
         if (fontsize == null) {
             prop.setProperty("reftree_fontsize", "11");
+        } else {
+            try {
+                Integer.decode(fontsize);
+            } catch (NumberFormatException e) {
+                throw new HeapStatsConfigException(resource.getString("invalid.option") + " reftree_fontsize=" + fontsize, e);
+            }
         }
-        
+
         /* Tick marker on X axis */
         if (prop.getProperty("tickmarker") == null) {
             prop.setProperty("tickmarker", "false");


### PR DESCRIPTION
Add a validation of reftree_fontsize to show error when a user sets a wrong value.

http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3197

![image](https://cloud.githubusercontent.com/assets/489607/19478284/ef1d5800-957c-11e6-8ad7-f51838c3fe9c.png)
