### PR TITLE
[WIP]CategoryAxis and NumberAxis integration

### DIFF
--- a/analyzer/fx/heapstats.properties
+++ b/analyzer/fx/heapstats.properties
@@ -15,3 +15,4 @@ datetime_format=yyyy/MM/dd HH:mm:ss
 reftree_fontsize=11
 tickmarker=false
 x_tickunit=20
+x_numberaxis=true

--- a/analyzer/fx/heapstats.properties
+++ b/analyzer/fx/heapstats.properties
@@ -14,3 +14,4 @@ datetime_format=yyyy/MM/dd HH:mm:ss
 #plugins=
 reftree_fontsize=11
 tickmarker=false
+x_tickunit=20

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
@@ -172,12 +172,10 @@ public class WindowController implements Initializable {
         
         Callback<Class<?>, Object> origFactory = loader.getControllerFactory();
         loader.setControllerFactory(c -> {
-                                            System.out.println(c);
                                             if(c.equals(LogResourcesControllerBase.class)){
                                                 return HeapStatsUtils.isNumberAxis() ? new LogResourcesNumberController() : null; // TODO: implement CategoryAxis
                                             }
                                             else{
-                                                System.out.println("unmatch");
                                                 try{
                                                     return c.getConstructor().newInstance();
                                                 }

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
@@ -57,10 +57,10 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
-import javafx.util.Callback;
 import jp.co.ntt.oss.heapstats.lambda.FunctionWrapper;
 import jp.co.ntt.oss.heapstats.plugin.PluginController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.log.LogController;
+import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesCategoryController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesControllerBase;
 import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesNumberController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.SnapShotController;
@@ -170,10 +170,9 @@ public class WindowController implements Initializable {
         ResourceBundle pluginResource = ResourceBundle.getBundle("logResources", new Locale(HeapStatsUtils.getLanguage()), pluginClassLoader);
         FXMLLoader loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName), pluginResource);
         
-        Callback<Class<?>, Object> origFactory = loader.getControllerFactory();
         loader.setControllerFactory(c -> {
                                             if(c.equals(LogResourcesControllerBase.class)){
-                                                return HeapStatsUtils.isNumberAxis() ? new LogResourcesNumberController() : null; // TODO: implement CategoryAxis
+                                                return HeapStatsUtils.isNumberAxis() ? new LogResourcesNumberController() : new LogResourcesCategoryController();
                                             }
                                             else{
                                                 try{

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
@@ -20,6 +20,7 @@ package jp.co.ntt.oss.heapstats;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.DirectoryStream;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
-import java.util.Optional;
 import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
@@ -57,9 +57,12 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
+import javafx.util.Callback;
 import jp.co.ntt.oss.heapstats.lambda.FunctionWrapper;
 import jp.co.ntt.oss.heapstats.plugin.PluginController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.log.LogController;
+import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesControllerBase;
+import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesNumberController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.SnapShotController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder.ThreadRecorderController;
 import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
@@ -136,21 +139,8 @@ public class WindowController implements Initializable {
         dialog.setTitle("About HeapStats Analyzer");
         dialog.showAndWait();
     }
-
-    private void addPlugin(String packageName){
-        String lastPackageName = packageName.substring(packageName.lastIndexOf('.') + 1);
-        packageName = packageName.replace('.', '/');
-        String fxmlName = packageName + "/" + lastPackageName + ".fxml";
-        FXMLLoader loader;
-
-        try{
-            ResourceBundle pluginResource = ResourceBundle.getBundle(lastPackageName + "Resources", new Locale(HeapStatsUtils.getLanguage()), pluginClassLoader);
-            loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName), pluginResource);
-        }
-        catch(MissingResourceException e){
-            loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName));
-        }
-
+    
+    private void loadAndRegisterFXML(FXMLLoader loader){
         Parent root;
 
         try {
@@ -173,6 +163,48 @@ public class WindowController implements Initializable {
         tabPane.getTabs().add(tab);
 
         pluginList.put(controller.getPluginName(), controller);
+    }
+    
+    private void loadLogPlugin(){
+        String fxmlName = LogController.class.getPackage().getName().replace('.', '/') + "/log.fxml";
+        ResourceBundle pluginResource = ResourceBundle.getBundle("logResources", new Locale(HeapStatsUtils.getLanguage()), pluginClassLoader);
+        FXMLLoader loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName), pluginResource);
+        
+        Callback<Class<?>, Object> origFactory = loader.getControllerFactory();
+        loader.setControllerFactory(c -> {
+                                            System.out.println(c);
+                                            if(c.equals(LogResourcesControllerBase.class)){
+                                                return HeapStatsUtils.isNumberAxis() ? new LogResourcesNumberController() : null; // TODO: implement CategoryAxis
+                                            }
+                                            else{
+                                                System.out.println("unmatch");
+                                                try{
+                                                    return c.getConstructor().newInstance();
+                                                }
+                                                catch(NoSuchMethodException | InstantiationException | IllegalAccessException | InvocationTargetException e){
+                                                    throw new RuntimeException(e);
+                                                }
+                                            }
+                                         });
+        
+        loadAndRegisterFXML(loader);
+    }
+
+    private void addPlugin(String packageName){
+        String lastPackageName = packageName.substring(packageName.lastIndexOf('.') + 1);
+        packageName = packageName.replace('.', '/');
+        String fxmlName = packageName + "/" + lastPackageName + ".fxml";
+        FXMLLoader loader;
+
+        try{
+            ResourceBundle pluginResource = ResourceBundle.getBundle(lastPackageName + "Resources", new Locale(HeapStatsUtils.getLanguage()), pluginClassLoader);
+            loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName), pluginResource);
+        }
+        catch(MissingResourceException e){
+            loader = new FXMLLoader(pluginClassLoader.getResource(fxmlName));
+        }
+
+        loadAndRegisterFXML(loader);
     }
 
     public static WindowController getInstance(){
@@ -319,6 +351,9 @@ public class WindowController implements Initializable {
 
         pluginClassLoader = (jarURLList == null) ? WindowController.class.getClassLoader() : new URLClassLoader(jarURLList);
         FXMLLoader.setDefaultClassLoader(pluginClassLoader);
+        
+        /* Load base plugins */
+        loadLogPlugin();
 
         List<String> plugins = HeapStatsUtils.getPlugins();
         plugins.stream().forEach(s -> addPlugin(s));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/LogController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/LogController.java
@@ -51,7 +51,7 @@ import jp.co.ntt.oss.heapstats.lambda.ConsumerWrapper;
 import jp.co.ntt.oss.heapstats.lambda.FunctionWrapper;
 import jp.co.ntt.oss.heapstats.plugin.PluginController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogDetailsController;
-import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesController;
+import jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesControllerBase;
 import jp.co.ntt.oss.heapstats.task.ParseLogFile;
 import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
 import jp.co.ntt.oss.heapstats.utils.TaskAdapter;
@@ -64,7 +64,7 @@ import jp.co.ntt.oss.heapstats.utils.TaskAdapter;
 public class LogController extends PluginController implements Initializable {
 
     @FXML
-    private LogResourcesController logResourcesController;
+    private LogResourcesControllerBase logResourcesController;
 
     @FXML
     private LogDetailsController logDetailsController;

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesCategoryController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesCategoryController.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2016 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs;
+
+import java.net.URL;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javafx.concurrent.Task;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.StackedAreaChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.input.MouseEvent;
+import jp.co.ntt.oss.heapstats.container.log.DiffData;
+import jp.co.ntt.oss.heapstats.container.log.LogData;
+
+/**
+ * FXML Controller class for "Resource Data" tab in LogData plugin.
+ */
+public class LogResourcesCategoryController extends LogResourcesControllerBase {
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+        javaCPUChart = new StackedAreaChart<>(new CategoryAxis(), new NumberAxis("%", 0.0d, 100.d, 10.0d));
+        systemCPUChart = new StackedAreaChart<>(new CategoryAxis(), new NumberAxis("%", 0.0d, 100.d, 10.0d));
+        javaMemoryChart = new LineChart<>(new CategoryAxis(), new NumberAxis());
+        safepointChart = new LineChart<>(new CategoryAxis(), new NumberAxis());
+        safepointTimeChart = new LineChart<>(new CategoryAxis(), new NumberAxis());
+        monitorChart = new LineChart<>(new CategoryAxis(), new NumberAxis());
+        threadChart = new LineChart<>(new CategoryAxis(), new NumberAxis());
+
+        super.initialize(url, rb);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void showChartPopup(XYChart chart, Object xValue, MouseEvent event, Function<? super Number, String> labelFunc) {
+        XYChart<String, Number> pChart = (XYChart<String, Number>)chart;
+        String label = pChart.getData()
+                             .stream()
+                             .map(s -> s.getName() + " = " + s.getData()
+                                                              .stream()
+                                                              .filter(d -> d.getXValue().equals(xValue))
+                                                              .map(d -> labelFunc.apply(d.getYValue()))
+                                                              .findAny()
+                                                              .orElse("<none>"))
+                             .collect(Collectors.joining("\n"));
+        
+        popupText.setText(xValue.toString() + "\n" + label);
+        chartPopup.show(chart, event.getScreenX() + 15.0d, event.getScreenY() + 3.0d);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private class DrawLogCategoryChartTask extends LogResourcesControllerBase.DrawLogChartTask {
+        
+        public DrawLogCategoryChartTask(List<LogData> targetLogData, List<DiffData> targetDiffData) {
+            super(targetLogData, targetDiffData);
+        }
+
+        @Override
+        protected void setChartRange() {
+            // Do nothing
+        }
+
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public Task<Void> createDrawResourceCharts(List<LogData> targetLogData, List<DiffData> targetDiffData) {
+        return new DrawLogCategoryChartTask(targetLogData, targetDiffData);
+    }
+
+}

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
@@ -471,10 +471,12 @@ public class LogResourcesController implements Initializable {
             long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(javaMemoryChart, threadChart)
                   .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / 100.0d))
                   .peek(a -> a.setLowerBound(startLogEpoch))
                   .forEach(a -> a.setUpperBound(endLogEpoch));
             Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
                   .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / 100.0d))
                   .peek(a -> a.setLowerBound(startDiffEpoch))
                   .forEach(a -> a.setUpperBound(endDiffEpoch));
             

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
@@ -471,12 +471,12 @@ public class LogResourcesController implements Initializable {
             long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(javaMemoryChart, threadChart)
                   .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / 100.0d))
+                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(a -> a.setLowerBound(startLogEpoch))
                   .forEach(a -> a.setUpperBound(endLogEpoch));
             Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
                   .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / 100.0d))
+                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(a -> a.setLowerBound(startDiffEpoch))
                   .forEach(a -> a.setUpperBound(endDiffEpoch));
             

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesControllerBase.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesControllerBase.java
@@ -36,6 +36,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
+import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.StackedAreaChart;
@@ -54,71 +55,85 @@ import jp.co.ntt.oss.heapstats.container.log.ArchiveData;
 import jp.co.ntt.oss.heapstats.container.log.DiffData;
 import jp.co.ntt.oss.heapstats.container.log.LogData;
 import jp.co.ntt.oss.heapstats.container.log.SummaryData;
-import jp.co.ntt.oss.heapstats.utils.EpochTimeConverter;
 import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
 
 /**
- * FXML Controller class for "Resource Data" tab in LogData plugin.
+ * FXML base Controller class for "Resource Data" tab in LogData plugin.
+ * Controller of log resource tab should inherit this class.
  */
-public class LogResourcesController implements Initializable {
+public abstract class LogResourcesControllerBase implements Initializable {
 
     @FXML
     private GridPane chartGrid;
 
     @FXML
-    private StackedAreaChart<Number, Double> javaCPUChart;
+    protected StackPane javaCPUChartPane;
+    
+    protected StackedAreaChart javaCPUChart;
 
-    private XYChart.Series<Number, Double> javaUserUsage;
+    private XYChart.Series javaUserUsage;
 
-    private XYChart.Series<Number, Double> javaSysUsage;
-
-    @FXML
-    private StackedAreaChart<Number, Double> systemCPUChart;
-
-    private XYChart.Series<Number, Double> systemUserUsage;
-
-    private XYChart.Series<Number, Double> systemNiceUsage;
-
-    private XYChart.Series<Number, Double> systemSysUsage;
-
-    private XYChart.Series<Number, Double> systemIdleUsage;
-
-    private XYChart.Series<Number, Double> systemIOWaitUsage;
-
-    private XYChart.Series<Number, Double> systemIRQUsage;
-
-    private XYChart.Series<Number, Double> systemSoftIRQUsage;
-
-    private XYChart.Series<Number, Double> systemStealUsage;
-
-    private XYChart.Series<Number, Double> systemGuestUsage;
+    private XYChart.Series javaSysUsage;
 
     @FXML
-    private LineChart<Number, Long> javaMemoryChart;
+    protected StackPane systemCPUChartPane;
+    
+    protected StackedAreaChart systemCPUChart;
 
-    private XYChart.Series<Number, Long> javaVSZUsage;
+    private XYChart.Series systemUserUsage;
 
-    private XYChart.Series<Number, Long> javaRSSUsage;
+    private XYChart.Series systemNiceUsage;
+
+    private XYChart.Series systemSysUsage;
+
+    private XYChart.Series systemIdleUsage;
+
+    private XYChart.Series systemIOWaitUsage;
+
+    private XYChart.Series systemIRQUsage;
+
+    private XYChart.Series systemSoftIRQUsage;
+
+    private XYChart.Series systemStealUsage;
+
+    private XYChart.Series systemGuestUsage;
 
     @FXML
-    private LineChart<Number, Long> safepointChart;
+    protected StackPane javaMemoryChartPane;
+    
+    protected LineChart javaMemoryChart;
 
-    private XYChart.Series<Number, Long> safepoints;
+    private XYChart.Series javaVSZUsage;
 
-    @FXML
-    private LineChart<Number, Long> safepointTimeChart;
-
-    private XYChart.Series<Number, Long> safepointTime;
-
-    @FXML
-    private LineChart<Number, Long> threadChart;
-
-    private XYChart.Series<Number, Long> threads;
+    private XYChart.Series javaRSSUsage;
 
     @FXML
-    private LineChart<Number, Long> monitorChart;
+    protected StackPane safepointChartPane;
+    
+    protected LineChart safepointChart;
 
-    private XYChart.Series<Number, Long> monitors;
+    private XYChart.Series safepoints;
+
+    @FXML
+    protected StackPane safepointTimeChartPane;
+    
+    protected LineChart safepointTimeChart;
+
+    private XYChart.Series safepointTime;
+
+    @FXML
+    protected StackPane threadChartPane;
+    
+    protected LineChart threadChart;
+
+    private XYChart.Series threads;
+
+    @FXML
+    protected StackPane monitorChartPane;
+    
+    protected LineChart monitorChart;
+
+    private XYChart.Series monitors;
 
     @FXML
     private TableView<SummaryData.SummaryDataEntry> procSummary;
@@ -129,17 +144,15 @@ public class LogResourcesController implements Initializable {
     @FXML
     private TableColumn<SummaryData.SummaryDataEntry, String> valueColumn;
 
-    private Popup chartPopup;
+    protected Popup chartPopup;
 
-    private Label popupText;
+    protected Label popupText;
 
     private ObjectProperty<ObservableList<ArchiveData>> archiveList;
 
     private List<LocalDateTime> suspectList;
     
     private ResourceBundle resource;
-    
-    private EpochTimeConverter epochTimeConverter;
 
     /**
      * Initializes the controller class.
@@ -151,9 +164,48 @@ public class LogResourcesController implements Initializable {
         categoryColumn.setCellValueFactory(new PropertyValueFactory<>("category"));
         valueColumn.setCellValueFactory(new PropertyValueFactory<>("value"));
 
+        javaCPUChartPane.getChildren().add(0, javaCPUChart);
+        javaCPUChart.setId("javaCPUChart");
+        javaCPUChart.setCreateSymbols(false);
+        javaCPUChart.setTitle(resource.getString("chart.javacpu"));
+        systemCPUChartPane.getChildren().add(0, systemCPUChart);
+        systemCPUChart.setId("systemCPUChart");
+        systemCPUChart.setCreateSymbols(false);
+        systemCPUChart.setTitle(resource.getString("chart.systemcpu"));
+        javaMemoryChartPane.getChildren().add(0, javaMemoryChart);
+        javaMemoryChart.setId("javaMemoryChart");
+        javaMemoryChart.setCreateSymbols(false);
+        javaMemoryChart.setTitle(resource.getString("chart.nativememory"));
+        javaMemoryChart.getYAxis().setLabel("MB");
+        safepointChartPane.getChildren().add(0, safepointChart);
+        safepointChart.setId("safepointChart");
+        safepointChart.setCreateSymbols(false);
+        safepointChart.setTitle(resource.getString("chart.safepoint.count"));
+        safepointTimeChartPane.getChildren().add(0, safepointTimeChart);
+        safepointTimeChart.setId("safepointTimeChart");
+        safepointTimeChart.setCreateSymbols(false);
+        safepointTimeChart.setTitle(resource.getString("chart.safepoint.time"));
+        safepointTimeChart.getYAxis().setLabel("ms");
+        monitorChartPane.getChildren().add(0, monitorChart);
+        monitorChart.setId("monitorChart");
+        monitorChart.setCreateSymbols(false);
+        monitorChart.setTitle(resource.getString("chart.monitorcontention"));
+        threadChartPane.getChildren().add(0, threadChart);
+        threadChart.setId("threadChart");
+        threadChart.setCreateSymbols(false);
+        threadChart.setTitle(resource.getString("chart.thread"));
+
         String bgcolor = "-fx-background-color: " + HeapStatsUtils.getChartBgColor() + ";";
         Stream.of(javaCPUChart, systemCPUChart, javaMemoryChart, safepointChart, safepointTimeChart, threadChart, monitorChart)
               .peek(c -> c.lookup(".chart").setStyle(bgcolor))
+              .peek(c -> c.setAnimated(false))
+              .peek(c -> c.setLegendVisible(false))
+              .peek(c -> c.setMinHeight(0.0d))
+              .peek(c -> c.setMinWidth(0.0d))
+              .peek(c -> c.setOnMouseMoved(this::onChartMouseMoved))
+              .peek(c -> c.setOnMouseExited(this::onChartMouseExited))
+              .peek(c -> c.getXAxis().setTickLabelsVisible(false))
+              .peek(c -> ((NumberAxis)c.getYAxis()).setMinorTickVisible(false))
               .forEach(c -> c.getXAxis().setTickMarkVisible(HeapStatsUtils.getTickMarkerSwitch()));
 
         initializeChartSeries();
@@ -163,8 +215,6 @@ public class LogResourcesController implements Initializable {
         popupText.setStyle("-fx-font-family: monospace; -fx-text-fill: white; -fx-background-color: black;");
         chartPopup.getContent().add(popupText);
         archiveList = new SimpleObjectProperty<>();
-        
-        epochTimeConverter = new EpochTimeConverter();
     }
 
     /**
@@ -233,33 +283,17 @@ public class LogResourcesController implements Initializable {
      * @param event Mouse event.
      * @param labelFunc Function to format label string.
      */
-    private void showChartPopup(XYChart<Number, ? extends Number> chart, Number xValue, MouseEvent event, Function<? super Number, String> labelFunc) {
-        boolean isContained = chart.getData()
-                                   .stream()
-                                   .flatMap(s -> s.getData().stream())
-                                   .anyMatch(d -> d.getXValue().longValue() == xValue.longValue());
-        if(isContained){
-            String label = chart.getData()
-                                .stream()
-                                .map(s -> s.getName() + " = " + s.getData()
-                                                                 .stream()
-                                                                 .filter(d -> d.getXValue().longValue() == xValue.longValue())
-                                                                 .map(d -> labelFunc.apply(d.getYValue()))
-                                                                 .findAny()
-                                                                 .get())
-                                .collect(Collectors.joining("\n"));
-            popupText.setText(epochTimeConverter.toString(xValue) + "\n" + label);
-            chartPopup.show(chart, event.getScreenX() + 15.0d, event.getScreenY() + 3.0d);
-        }
-    }
+    protected abstract void showChartPopup(XYChart chart, Object xValue, MouseEvent event, Function<? super Number, String> labelFunc);
 
-    @FXML
     @SuppressWarnings("unchecked")
     private void onChartMouseMoved(MouseEvent event) {
-        XYChart<Number, ? extends Number> chart = (XYChart<Number, ? extends Number>) event.getSource();
-        NumberAxis xAxis = (NumberAxis)chart.getXAxis();
-        Function<? super Number, String> labelFunc;
+        XYChart chart = (XYChart)event.getSource();
+        double startX = chart.getXAxis().getLayoutX();
+        if(!HeapStatsUtils.isNumberAxis()){
+            startX += ((CategoryAxis)chart.getXAxis()).getStartMargin();
+        }
 
+        Function<? super Number, String> labelFunc;
         if ((chart == javaCPUChart) || (chart == systemCPUChart)) {
             labelFunc = d -> String.format("%.02f %%", d);
         } else if (chart == javaMemoryChart) {
@@ -269,17 +303,17 @@ public class LogResourcesController implements Initializable {
         } else {
             labelFunc = d -> d.toString();
         }
-
-        Optional.ofNullable(chart.getXAxis().getValueForDisplay(event.getX() - xAxis.getLayoutX()))
+        
+        Optional.ofNullable(chart.getXAxis().getValueForDisplay(event.getX() - startX))
                 .ifPresent(v -> showChartPopup(chart, v, event, labelFunc));
     }
-
-    @FXML
+    
     private void onChartMouseExited(MouseEvent event) {
         chartPopup.hide();
     }
-
-    private void drawLineInternal(StackPane target, List<Number> drawList, String style) {
+    
+    @SuppressWarnings("unchecked")
+    private void drawLineInternal(StackPane target, List drawList, String style) {
         AnchorPane anchor = null;
         XYChart chart = null;
 
@@ -308,19 +342,27 @@ public class LogResourcesController implements Initializable {
                 .filter(r -> r.getStyle().equals(style))
                 .collect(Collectors.toList()));
 
-        NumberAxis xAxis = (NumberAxis) chart.getXAxis();
+        Axis xAxis = chart.getXAxis();
         Axis yAxis = chart.getYAxis();
         Label chartTitle = (Label) chart.getChildrenUnmodifiable().stream()
                 .filter(n -> n.getStyleClass().contains("chart-title"))
                 .findFirst()
                 .get();
-
-        double startX = xAxis.getLayoutX() + 4.0d;
+        
+        double startX = xAxis.getLayoutX();
+        if(xAxis instanceof CategoryAxis){
+            startX += ((CategoryAxis)xAxis).getStartMargin() - 1.0d;
+        }
+        else{
+            startX += 4.0d;
+        }
+        
+        final double xPos = startX;
         double yPos = yAxis.getLayoutY() + chartTitle.getLayoutY() + chartTitle.getHeight();
-        List<Rectangle> rectList = drawList.stream()
-                .map(t -> new Rectangle(xAxis.getDisplayPosition(t) + startX, yPos, 2.0d, yAxis.getHeight()))
-                .peek(r -> ((Rectangle) r).setStyle(style))
-                .collect(Collectors.toList());
+        List<Rectangle> rectList = (List<Rectangle>)drawList.stream()
+                                                            .map(x -> new Rectangle(xAxis.getDisplayPosition(x) + xPos, yPos, 2.0d, yAxis.getHeight()))
+                                                            .peek(r -> ((Rectangle)r).setStyle(style))
+                                                            .collect(Collectors.toList());
         anchorChildren.addAll(rectList);
     }
 
@@ -329,11 +371,14 @@ public class LogResourcesController implements Initializable {
         if (archiveList.get().isEmpty()) {
             return;
         }
-
-        List<Number> archiveDateList = archiveList.get()
-                                                  .stream()
-                                                  .map(a -> a.getDate().atZone(ZoneId.systemDefault()).toEpochSecond())
-                                                  .collect(Collectors.toList());
+        
+        Function<? super ArchiveData, String> categoryMapFunc = a -> a.getDate().format(HeapStatsUtils.getDateTimeFormatter());
+        Function<? super ArchiveData, Number> numberMapFunc = a -> a.getDate().atZone(ZoneId.systemDefault()).toEpochSecond();
+        
+        List archiveDateList = archiveList.get()
+                                          .stream()
+                                          .map(HeapStatsUtils.isNumberAxis() ? numberMapFunc : categoryMapFunc)
+                                          .collect(Collectors.toList());
         chartGrid.getChildren().stream()
                 .filter(n -> n instanceof StackPane)
                 .forEach(p -> drawLineInternal((StackPane) p, archiveDateList, "-fx-fill: black;"));
@@ -350,9 +395,12 @@ public class LogResourcesController implements Initializable {
             return;
         }
 
-        List<Number> suspectRebootDateList = suspectList.stream()
-                                                        .map(d -> d.atZone(ZoneId.systemDefault()).toEpochSecond())
-                                                        .collect(Collectors.toList());
+        Function<? super LocalDateTime, String> categoryMapFunc = d -> d.format(HeapStatsUtils.getDateTimeFormatter());
+        Function<? super LocalDateTime, Number> numberMapFunc = d -> d.atZone(ZoneId.systemDefault()).toEpochSecond();
+        
+        List suspectRebootDateList = suspectList.stream()
+                                                .map(HeapStatsUtils.isNumberAxis() ? numberMapFunc : categoryMapFunc)
+                                                .collect(Collectors.toList());
         chartGrid.getChildren().stream()
                 .filter(n -> n instanceof StackPane)
                 .forEach(p -> drawLineInternal((StackPane) p, suspectRebootDateList, "-fx-fill: yellow;"));
@@ -369,40 +417,40 @@ public class LogResourcesController implements Initializable {
     /**
      * Task class for drawing log chart data.
      */
-    private class DrawLogChartTask extends Task<Void> {
+    protected abstract class DrawLogChartTask extends Task<Void> {
 
         /* Java CPU */
-        private final ObservableList<XYChart.Data<Number, Double>> javaUserUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> javaSysUsageBuf;
+        private final ObservableList<XYChart.Data> javaUserUsageBuf;
+        private final ObservableList<XYChart.Data> javaSysUsageBuf;
 
         /* System CPU */
-        private final ObservableList<XYChart.Data<Number, Double>> systemUserUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemNiceUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemSysUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemIdleUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemIOWaitUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemIRQUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemSoftIRQUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemStealUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Double>> systemGuestUsageBuf;
+        private final ObservableList<XYChart.Data> systemUserUsageBuf;
+        private final ObservableList<XYChart.Data> systemNiceUsageBuf;
+        private final ObservableList<XYChart.Data> systemSysUsageBuf;
+        private final ObservableList<XYChart.Data> systemIdleUsageBuf;
+        private final ObservableList<XYChart.Data> systemIOWaitUsageBuf;
+        private final ObservableList<XYChart.Data> systemIRQUsageBuf;
+        private final ObservableList<XYChart.Data> systemSoftIRQUsageBuf;
+        private final ObservableList<XYChart.Data> systemStealUsageBuf;
+        private final ObservableList<XYChart.Data> systemGuestUsageBuf;
 
         /* Java Memory */
-        private final ObservableList<XYChart.Data<Number, Long>> javaVSZUsageBuf;
-        private final ObservableList<XYChart.Data<Number, Long>> javaRSSUsageBuf;
+        private final ObservableList<XYChart.Data> javaVSZUsageBuf;
+        private final ObservableList<XYChart.Data> javaRSSUsageBuf;
 
         /* Safepoints */
-        private final ObservableList<XYChart.Data<Number, Long>> safepointsBuf;
-        private final ObservableList<XYChart.Data<Number, Long>> safepointTimeBuf;
+        private final ObservableList<XYChart.Data> safepointsBuf;
+        private final ObservableList<XYChart.Data> safepointTimeBuf;
 
         /* Threads */
-        private final ObservableList<XYChart.Data<Number, Long>> threadsBuf;
+        private final ObservableList<XYChart.Data> threadsBuf;
 
         /* Monitor contantion */
-        private final ObservableList<XYChart.Data<Number, Long>> monitorsBuf;
+        private final ObservableList<XYChart.Data> monitorsBuf;
 
-        private final List<LogData> targetLogData;
+        protected final List<LogData> targetLogData;
 
-        private final List<DiffData> targetDiffData;
+        protected final List<DiffData> targetDiffData;
 
         private long loopCount;
 
@@ -454,7 +502,8 @@ public class LogResourcesController implements Initializable {
         }
 
         private void addLogData(LogData data) {
-            long time = data.getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            Object time = HeapStatsUtils.isNumberAxis() ? data.getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond()
+                                                        : data.getDateTime().format(HeapStatsUtils.getDateTimeFormatter()); 
 
             javaVSZUsageBuf.add(new XYChart.Data<>(time, data.getJavaVSSize() / 1024 / 1024));
             javaRSSUsageBuf.add(new XYChart.Data<>(time, data.getJavaRSSize() / 1024 / 1024));
@@ -462,23 +511,12 @@ public class LogResourcesController implements Initializable {
 
             updateProgress();
         }
+        
+        protected abstract void setChartRange();
 
+        @SuppressWarnings("unchecked")
         private void setChartData() {
-            /* Set chart range */
-            long startLogEpoch = targetLogData.get(0).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
-            long endLogEpoch = targetLogData.get(targetLogData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
-            long startDiffEpoch = targetDiffData.get(0).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
-            long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
-            Stream.of(javaMemoryChart, threadChart)
-                  .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / HeapStatsUtils.getXTickUnit()))
-                  .peek(a -> a.setLowerBound(startLogEpoch))
-                  .forEach(a -> a.setUpperBound(endLogEpoch));
-            Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
-                  .map(c -> (NumberAxis)c.getXAxis())
-                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / HeapStatsUtils.getXTickUnit()))
-                  .peek(a -> a.setLowerBound(startDiffEpoch))
-                  .forEach(a -> a.setUpperBound(endDiffEpoch));
+            setChartRange();
             
             /* Replace new chart data */
             javaUserUsage.setData(javaUserUsageBuf);
@@ -555,9 +593,7 @@ public class LogResourcesController implements Initializable {
      *
      * @return Task instance to draw charts.
      */
-    public Task<Void> createDrawResourceCharts(List<LogData> targetLogData, List<DiffData> targetDiffData) {
-        return new DrawLogChartTask(targetLogData, targetDiffData);
-    }
+    public abstract Task<Void> createDrawResourceCharts(List<LogData> targetLogData, List<DiffData> targetDiffData);
 
     /**
      * Get HeapStats ZIP archive list as Property.

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesControllerBase.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesControllerBase.java
@@ -481,7 +481,8 @@ public abstract class LogResourcesControllerBase implements Initializable {
         }
 
         private void addDiffData(DiffData data) {
-            long time = data.getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            Object time = HeapStatsUtils.isNumberAxis() ? data.getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond()
+                                                        : data.getDateTime().format(HeapStatsUtils.getDateTimeFormatter());
 
             javaUserUsageBuf.add(new XYChart.Data<>(time, data.getJavaUserUsage()));
             javaSysUsageBuf.add(new XYChart.Data<>(time, data.getJavaSysUsage()));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesNumberController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesNumberController.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2016 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs;
+
+import java.net.URL;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.ResourceBundle;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import javafx.concurrent.Task;
+import javafx.scene.chart.LineChart;
+import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.StackedAreaChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.input.MouseEvent;
+import jp.co.ntt.oss.heapstats.container.log.DiffData;
+import jp.co.ntt.oss.heapstats.container.log.LogData;
+import jp.co.ntt.oss.heapstats.utils.EpochTimeConverter;
+import jp.co.ntt.oss.heapstats.utils.HeapStatsUtils;
+
+/**
+ * FXML Controller class for "Resource Data" tab in LogData plugin.
+ */
+public class LogResourcesNumberController extends LogResourcesControllerBase {
+    
+    private EpochTimeConverter epochTimeConverter;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void initialize(URL url, ResourceBundle rb) {
+        javaCPUChart = new StackedAreaChart<>(new NumberAxis(), new NumberAxis("%", 0.0d, 100.d, 10.0d));
+        systemCPUChart = new StackedAreaChart<>(new NumberAxis(), new NumberAxis("%", 0.0d, 100.d, 10.0d));
+        javaMemoryChart = new LineChart<>(new NumberAxis(), new NumberAxis());
+        safepointChart = new LineChart<>(new NumberAxis(), new NumberAxis());
+        safepointTimeChart = new LineChart<>(new NumberAxis(), new NumberAxis());
+        monitorChart = new LineChart<>(new NumberAxis(), new NumberAxis());
+        threadChart = new LineChart<>(new NumberAxis(), new NumberAxis());
+        
+        Stream.of(javaCPUChart, systemCPUChart, javaMemoryChart, safepointChart, safepointTimeChart, monitorChart, threadChart)
+              .peek(c -> ((NumberAxis)c.getXAxis()).setMinorTickVisible(false))
+              .forEach(c -> c.getXAxis().setAutoRanging(false));
+        
+        epochTimeConverter = new EpochTimeConverter();
+
+        super.initialize(url, rb);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    protected void showChartPopup(XYChart chart, Object xValue, MouseEvent event, Function<? super Number, String> labelFunc) {
+        boolean isContained = ((XYChart<Number, Number>)chart).getData()
+                                                              .stream()
+                                                              .flatMap(s -> s.getData().stream())
+                                                              .anyMatch(d -> d.getXValue().longValue() == ((Number)xValue).longValue());
+        if(isContained){
+            String label = ((XYChart<Number, Number>)chart).getData()
+                                                           .stream()
+                                                           .map(s -> s.getName() + " = " + s.getData()
+                                                                                            .stream()
+                                                                                            .filter(d -> d.getXValue().longValue() == ((Number)xValue).longValue())
+                                                                                            .map(d -> labelFunc.apply(d.getYValue()))
+                                                                                            .findAny()
+                                                                                            .get())
+                                                           .collect(Collectors.joining("\n"));
+            popupText.setText(epochTimeConverter.toString((Number)xValue) + "\n" + label);
+            chartPopup.show(chart, event.getScreenX() + 15.0d, event.getScreenY() + 3.0d);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    private class DrawLogNumberChartTask extends LogResourcesControllerBase.DrawLogChartTask {
+        
+        public DrawLogNumberChartTask(List<LogData> targetLogData, List<DiffData> targetDiffData) {
+            super(targetLogData, targetDiffData);
+        }
+
+        @Override
+        protected void setChartRange() {
+            long startLogEpoch = targetLogData.get(0).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            long endLogEpoch = targetLogData.get(targetLogData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            long startDiffEpoch = targetDiffData.get(0).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            long endDiffEpoch = targetDiffData.get(targetDiffData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
+            Stream.of(javaMemoryChart, threadChart)
+                  .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endLogEpoch - startLogEpoch) / HeapStatsUtils.getXTickUnit()))
+                  .peek(a -> a.setLowerBound(startLogEpoch))
+                  .forEach(a -> a.setUpperBound(endLogEpoch));
+            Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
+                  .map(c -> (NumberAxis)c.getXAxis())
+                  .peek(a -> a.setTickUnit((endDiffEpoch - startDiffEpoch) / HeapStatsUtils.getXTickUnit()))
+                  .peek(a -> a.setLowerBound(startDiffEpoch))
+                  .forEach(a -> a.setUpperBound(endDiffEpoch));
+        }
+
+    }
+
+    /**
+     * @{inheritDoc}
+     */
+    @Override
+    public Task<Void> createDrawResourceCharts(List<LogData> targetLogData, List<DiffData> targetDiffData) {
+        return new DrawLogNumberChartTask(targetLogData, targetDiffData);
+    }
+
+}

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/SnapShotController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/SnapShotController.java
@@ -20,6 +20,7 @@ package jp.co.ntt.oss.heapstats.plugin.builtin.snapshot;
 import java.io.File;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -48,7 +49,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
-import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
@@ -375,7 +376,7 @@ public class SnapShotController extends PluginController implements Initializabl
         parseThread.start();
     }
 
-    private void drawRebootSuspectLine(XYChart<String, ? extends Number> target) {
+    private void drawRebootSuspectLine(XYChart<Number, ? extends Number> target) {
 
         if (target.getData().isEmpty() || target.getData().get(0).getData().isEmpty()) {
             return;
@@ -389,18 +390,18 @@ public class SnapShotController extends PluginController implements Initializabl
         ObservableList<Node> anchorChildren = anchor.getChildren();
         anchorChildren.clear();
 
-        CategoryAxis xAxis = (CategoryAxis) target.getXAxis();
+        NumberAxis xAxis = (NumberAxis)target.getXAxis();
         Axis yAxis = target.getYAxis();
         Label chartTitle = (Label) target.getChildrenUnmodifiable().stream()
                 .filter(n -> n.getStyleClass().contains("chart-title"))
                 .findFirst()
                 .get();
 
-        double startX = xAxis.getLayoutX() + xAxis.getStartMargin() - 1.0d;
+        double startX = xAxis.getLayoutX() + 4.0d;
         double yPos = yAxis.getLayoutY() + chartTitle.getLayoutY() + chartTitle.getHeight();
         List<Rectangle> rectList = summaryData.get().getRebootSuspectList()
                 .stream()
-                .map(d -> d.format(HeapStatsUtils.getDateTimeFormatter()))
+                .map(d -> d.atZone(ZoneId.systemDefault()).toEpochSecond())
                 .map(s -> new Rectangle(xAxis.getDisplayPosition(s) + startX, yPos, 4d, yAxis.getHeight()))
                 .peek(r -> ((Rectangle) r).setStyle("-fx-fill: yellow;"))
                 .collect(Collectors.toList());

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -20,6 +20,7 @@ package jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.tabs;
 import java.io.File;
 import java.net.URL;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -103,7 +104,7 @@ public class HistogramController implements Initializable {
     private Button selectFilterApplyBtn;
 
     @FXML
-    private StackedAreaChart<String, Long> topNChart;
+    private StackedAreaChart<Number, Long> topNChart;
 
     @FXML
     private AnchorPane topNChartAnchor;
@@ -145,7 +146,7 @@ public class HistogramController implements Initializable {
 
     private LongProperty currentObjectTag;
 
-    private Consumer<XYChart<String, ? extends Number>> drawRebootSuspectLine;
+    private Consumer<XYChart<Number, ? extends Number>> drawRebootSuspectLine;
 
     private Consumer<Task<Void>> taskExecutor;
 
@@ -223,8 +224,8 @@ public class HistogramController implements Initializable {
      * chart series as value.
      * @param objData ObjectData which is you want to build.
      */
-    private void buildTopNChartData(SnapShotHeader header, Map<String, XYChart.Series<String, Long>> seriesMap, ObjectData objData) {
-        XYChart.Series<String, Long> series = seriesMap.get(objData.getName());
+    private void buildTopNChartData(SnapShotHeader header, Map<String, XYChart.Series<Number, Long>> seriesMap, ObjectData objData) {
+        XYChart.Series<Number, Long> series = seriesMap.get(objData.getName());
 
         if (series == null) {
             series = new XYChart.Series<>();
@@ -233,10 +234,10 @@ public class HistogramController implements Initializable {
             seriesMap.put(objData.getName(), series);
         }
 
-        String time = header.getSnapShotDate().format(HeapStatsUtils.getDateTimeFormatter());
+        long time = header.getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long yValue = instanceGraph.get() ? objData.getCount()
                 : objData.getTotalSize() / 1024 / 1024;
-        XYChart.Data<String, Long> data = new XYChart.Data<>(time, yValue);
+        XYChart.Data<Number, Long> data = new XYChart.Data<>(time, yValue);
 
         series.getData().add(data);
         String unit = instanceGraph.get() ? "instances" : "MB";
@@ -244,7 +245,7 @@ public class HistogramController implements Initializable {
         Tooltip.install(data.getNode(), new Tooltip(tip));
     }
 
-    private void setTopNChartColor(XYChart.Series<String, Long> series) {
+    private void setTopNChartColor(XYChart.Series<Number, Long> series) {
         String color = ChartColorManager.getNextColor(series.getName());
 
         series.getNode().lookup(".chart-series-area-line").setStyle(String.format("-fx-stroke: %s;", color));
@@ -262,7 +263,14 @@ public class HistogramController implements Initializable {
      * @param seriesMap Chart series map which is contains class name as key,
      * chart series as value.
      */
-    private void onDiffTaskSucceeded(DiffCalculator diff, Map<String, XYChart.Series<String, Long>> seriesMap) {
+    private void onDiffTaskSucceeded(DiffCalculator diff, Map<String, XYChart.Series<Number, Long>> seriesMap) {
+        /* Set chart range */
+        long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
+        long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
+        NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
+        xAxis.setLowerBound(startEpoch);
+        xAxis.setUpperBound(endEpoch);
+        
         topNList.set(FXCollections.observableMap(diff.getTopNList()));
 
         currentTarget.get().stream()
@@ -442,7 +450,7 @@ public class HistogramController implements Initializable {
     public Task<Void> getDrawTopNDataTask(List<SnapShotHeader> target, boolean includeOthers, Predicate<? super ObjectData> predicate) {
         topNChart.getData().clear();
         lastDiffTable.getItems().clear();
-        Map<String, XYChart.Series<String, Long>> seriesMap = new HashMap<>();
+        Map<String, XYChart.Series<Number, Long>> seriesMap = new HashMap<>();
 
         TaskAdapter<DiffCalculator> diff = new TaskAdapter<>(new DiffCalculator(target, HeapStatsUtils.getRankLevel(),
                 includeOthers, predicate, HeapStatsUtils.getReplaceClassName(), instanceGraph.get()));
@@ -456,7 +464,7 @@ public class HistogramController implements Initializable {
      *
      * @param drawRebootSuspectLine Consumer for drawing reboot line.
      */
-    public void setDrawRebootSuspectLine(Consumer<XYChart<String, ? extends Number>> drawRebootSuspectLine) {
+    public void setDrawRebootSuspectLine(Consumer<XYChart<Number, ? extends Number>> drawRebootSuspectLine) {
         this.drawRebootSuspectLine = drawRebootSuspectLine;
     }
 
@@ -512,7 +520,7 @@ public class HistogramController implements Initializable {
      *
      * @return TopN chart.
      */
-    public StackedAreaChart<String, Long> getTopNChart() {
+    public StackedAreaChart<Number, Long> getTopNChart() {
         return topNChart;
     }
 

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -269,7 +269,7 @@ public class HistogramController implements Initializable {
         long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
-        xAxis.setTickUnit((endEpoch - startEpoch) / 100.0d);
+        xAxis.setTickUnit((endEpoch - startEpoch) / HeapStatsUtils.getXTickUnit());
         xAxis.setLowerBound(startEpoch);
         xAxis.setUpperBound(endEpoch);
         

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/HistogramController.java
@@ -269,6 +269,7 @@ public class HistogramController implements Initializable {
         long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
         NumberAxis xAxis = (NumberAxis)topNChart.getXAxis();
+        xAxis.setTickUnit((endEpoch - startEpoch) / 100.0d);
         xAxis.setLowerBound(startEpoch);
         xAxis.setUpperBound(endEpoch);
         

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
@@ -262,6 +262,7 @@ public class SummaryController implements Initializable {
             long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(heapChart, instanceChart, gcTimeChart, metaspaceChart)
+                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / 100.0d))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setLowerBound(startEpoch))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setUpperBound(endEpoch))
                   .forEach(c -> Platform.runLater(() -> drawRebootSuspectLine.accept(c)));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/SummaryController.java
@@ -262,7 +262,7 @@ public class SummaryController implements Initializable {
             long startEpoch = currentTarget.get().get(0).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             long endEpoch = currentTarget.get().get(currentTarget.get().size() - 1).getSnapShotDate().atZone(ZoneId.systemDefault()).toEpochSecond();
             Stream.of(heapChart, instanceChart, gcTimeChart, metaspaceChart)
-                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / 100.0d))
+                  .peek(c -> ((NumberAxis)c.getXAxis()).setTickUnit((endEpoch - startEpoch) / HeapStatsUtils.getXTickUnit()))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setLowerBound(startEpoch))
                   .peek(c -> ((NumberAxis)c.getXAxis()).setUpperBound(endEpoch))
                   .forEach(c -> Platform.runLater(() -> drawRebootSuspectLine.accept(c)));

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/EpochTimeConverter.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/EpochTimeConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package jp.co.ntt.oss.heapstats.utils;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import javafx.util.StringConverter;
+
+/**
+ * String converter for epoch time.
+ * This class supports SECOND time unit ONLY.
+ * 
+ * @author Yasumasa Suenaga
+ */
+public class EpochTimeConverter extends StringConverter<Number>{
+
+    @Override
+    public String toString(Number object) {
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(object.longValue()), ZoneId.systemDefault()).format(HeapStatsUtils.getDateTimeFormatter());
+    }
+
+    @Override
+    public Number fromString(String string) {
+        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+    }
+    
+}

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -43,7 +43,6 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.TextArea;
 import javafx.scene.paint.Color;
 import jp.co.ntt.oss.heapstats.plugin.builtin.jvmlive.JVMLiveController;
-import jp.co.ntt.oss.heapstats.plugin.builtin.log.LogController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.snapshot.SnapShotController;
 import jp.co.ntt.oss.heapstats.plugin.builtin.threadrecorder.ThreadRecorderController;
 
@@ -206,6 +205,11 @@ public class HeapStatsUtils {
             }
         }
 
+        /* X Axis mode */
+        if (prop.getProperty("x_numberaxis") == null) {
+            prop.setProperty("x_numberaxis", "true");
+        }
+        
         /* Add shutdown hook for saving current settings. */
         Runnable savePropImpl = () -> {
             try (OutputStream out = Files.newOutputStream(properties, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
@@ -224,7 +228,6 @@ public class HeapStatsUtils {
      */
     public static List<String> getPlugins() {
         List<String> pluginList = new ArrayList<>();
-        pluginList.add(LogController.class.getPackage().getName());
         pluginList.add(SnapShotController.class.getPackage().getName());
         pluginList.add(ThreadRecorderController.class.getPackage().getName());
         pluginList.add(JVMLiveController.class.getPackage().getName());
@@ -363,6 +366,15 @@ public class HeapStatsUtils {
      */
     public static boolean getTickMarkerSwitch() {
         return Boolean.parseBoolean(prop.getProperty("tickmarker"));
+    }
+    
+    /**
+     * Get X Axis mode
+     * 
+     * @return true if HeapStats should use NumberAxis to draw charts.
+     */
+    public static boolean isNumberAxis(){
+        return Boolean.parseBoolean(prop.getProperty("x_numberaxis"));
     }
     
     /**

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -188,6 +188,18 @@ public class HeapStatsUtils {
             prop.setProperty("tickmarker", "false");
         }
 
+        /* TickUnit of X axis */
+        String xTickUnitStr = prop.getProperty("x_tickunit");
+        if (xTickUnitStr == null) {
+            prop.setProperty("x_tickunit", "20");
+        } else {
+            try {
+                Double.parseDouble(xTickUnitStr);
+            } catch (NumberFormatException e) {
+                throw new HeapStatsConfigException(resource.getString("invalid.option") + " x_tickunit=" + xTickUnitStr, e);
+            }
+        }
+
         /* Add shutdown hook for saving current settings. */
         Runnable savePropImpl = () -> {
             try (OutputStream out = Files.newOutputStream(properties, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE)) {
@@ -345,6 +357,15 @@ public class HeapStatsUtils {
      */
     public static boolean getTickMarkerSwitch() {
         return Boolean.parseBoolean(prop.getProperty("tickmarker"));
+    }
+    
+    /**
+     * Get TickUnit on X axis.
+     * 
+     * @return TickUnit of X axis.
+     */
+    public static double getXTickUnit(){
+        return Double.parseDouble(prop.getProperty("x_tickunit"));
     }
     
     /**

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
@@ -41,7 +41,7 @@
                     <children>
                         <LineChart id="threadChart" fx:id="threadChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.thread">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />
@@ -63,7 +63,7 @@
                     <children>
                         <StackedAreaChart id="javaCPUChart" fx:id="javaCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.javacpu">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
@@ -76,7 +76,7 @@
                     <children>
                         <StackedAreaChart id="systemCPUChart" fx:id="systemCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.systemcpu">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
@@ -89,7 +89,7 @@
                     <children>
                         <LineChart id="javaMemoryChart" fx:id="javaMemoryChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.nativememory">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />
@@ -102,7 +102,7 @@
                     <children>
                         <LineChart id="safepointChart" fx:id="safepointChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.count">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />
@@ -115,7 +115,7 @@
                     <children>
                         <LineChart id="safepointTimeChart" fx:id="safepointTimeChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.time">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="ms" side="LEFT" minorTickVisible="false" />
@@ -128,7 +128,7 @@
                     <children>
                         <LineChart id="monitorChart" fx:id="monitorChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.monitorcontention">
                             <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" minorTickVisible="false" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -41,7 +41,7 @@
                     <children>
                         <LineChart id="threadChart" fx:id="threadChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.thread">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />
@@ -63,7 +63,7 @@
                     <children>
                         <StackedAreaChart id="javaCPUChart" fx:id="javaCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.javacpu">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" tickUnit="10.0" upperBound="100.0d" />
@@ -76,7 +76,7 @@
                     <children>
                         <StackedAreaChart id="systemCPUChart" fx:id="systemCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.systemcpu">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" tickUnit="10.0" upperBound="100.0d" />
@@ -89,7 +89,7 @@
                     <children>
                         <LineChart id="javaMemoryChart" fx:id="javaMemoryChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.nativememory">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="MB" side="LEFT" />
@@ -102,7 +102,7 @@
                     <children>
                         <LineChart id="safepointChart" fx:id="safepointChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.count">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />
@@ -115,7 +115,7 @@
                     <children>
                         <LineChart id="safepointTimeChart" fx:id="safepointTimeChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.time">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" visible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis label="ms" side="LEFT" />
@@ -128,7 +128,7 @@
                     <children>
                         <LineChart id="monitorChart" fx:id="monitorChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.monitorcontention">
                             <xAxis>
-                                <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                             </xAxis>
                             <yAxis>
                                 <NumberAxis side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/resources.fxml
@@ -23,7 +23,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<AnchorPane layoutX="17.0" layoutY="20.0" minHeight="0.0" minWidth="0.0" prefHeight="479.0" prefWidth="772.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesController">
+<AnchorPane layoutX="17.0" layoutY="20.0" minHeight="0.0" minWidth="0.0" prefHeight="479.0" prefWidth="772.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="jp.co.ntt.oss.heapstats.plugin.builtin.log.tabs.LogResourcesControllerBase">
     <children>
         <GridPane fx:id="chartGrid" layoutY="26.0" minHeight="0.0" minWidth="0.0" stylesheets="@/jp/co/ntt/oss/heapstats/plugin/builtin/log/log.css" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="26.0">
             <columnConstraints>
@@ -37,16 +37,8 @@
                 <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
             </rowConstraints>
             <children>
-                <StackPane GridPane.columnIndex="1" GridPane.rowIndex="1">
+                <StackPane fx:id="threadChartPane" GridPane.columnIndex="1" GridPane.rowIndex="1">
                     <children>
-                        <LineChart id="threadChart" fx:id="threadChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.thread">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis side="LEFT" minorTickVisible="false" />
-                            </yAxis>
-                        </LineChart>
                         <AnchorPane fx:id="threadsAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
@@ -59,81 +51,33 @@
                         <TableView fx:constant="CONSTRAINED_RESIZE_POLICY" />
                     </columnResizePolicy>
                 </TableView>
-                <StackPane minHeight="0.0" minWidth="0.0">
+                <StackPane fx:id="javaCPUChartPane" minHeight="0.0" minWidth="0.0">
                     <children>
-                        <StackedAreaChart id="javaCPUChart" fx:id="javaCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.javacpu">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
-                            </yAxis>
-                        </StackedAreaChart>
                         <AnchorPane fx:id="javaCPUAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
-                <StackPane minHeight="0.0" minWidth="0.0" GridPane.columnIndex="1">
+                <StackPane fx:id="systemCPUChartPane" minHeight="0.0" minWidth="0.0" GridPane.columnIndex="1">
                     <children>
-                        <StackedAreaChart id="systemCPUChart" fx:id="systemCPUChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.systemcpu">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis autoRanging="false" label="\%" lowerBound="0.0" side="LEFT" upperBound="100.0d" tickUnit="10.0" minorTickVisible="false" />
-                            </yAxis>
-                        </StackedAreaChart>
                         <AnchorPane fx:id="systemCPUAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
-                <StackPane minHeight="0.0" minWidth="0.0" GridPane.rowIndex="1">
+                <StackPane fx:id="javaMemoryChartPane" minHeight="0.0" minWidth="0.0" GridPane.rowIndex="1">
                     <children>
-                        <LineChart id="javaMemoryChart" fx:id="javaMemoryChart" animated="false" createSymbols="false" legendSide="BOTTOM" legendVisible="true" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.nativememory">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />
-                            </yAxis>
-                        </LineChart>
                         <AnchorPane fx:id="javaMemoryAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
-                <StackPane minHeight="0.0" minWidth="0.0" GridPane.rowIndex="2">
+                <StackPane fx:id="safepointChartPane" minHeight="0.0" minWidth="0.0" GridPane.rowIndex="2">
                     <children>
-                        <LineChart id="safepointChart" fx:id="safepointChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.count">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis side="LEFT" minorTickVisible="false" />
-                            </yAxis>
-                        </LineChart>
                         <AnchorPane fx:id="safepointAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
-                <StackPane minHeight="0.0" minWidth="0.0" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                <StackPane fx:id="safepointTimeChartPane" minHeight="0.0" minWidth="0.0" GridPane.columnIndex="1" GridPane.rowIndex="2">
                     <children>
-                        <LineChart id="safepointTimeChart" fx:id="safepointTimeChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.safepoint.time">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis label="ms" side="LEFT" minorTickVisible="false" />
-                            </yAxis>
-                        </LineChart>
                         <AnchorPane fx:id="safepointTimeAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>
-                <StackPane minHeight="0.0" minWidth="0.0" GridPane.rowIndex="3">
+                <StackPane fx:id="monitorChartPane" minHeight="0.0" minWidth="0.0" GridPane.rowIndex="3">
                     <children>
-                        <LineChart id="monitorChart" fx:id="monitorChart" animated="false" createSymbols="false" legendVisible="false" minHeight="0.0" minWidth="0.0" onMouseExited="#onChartMouseExited" onMouseMoved="#onChartMouseMoved" title="%chart.monitorcontention">
-                            <xAxis>
-                                <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
-                            </xAxis>
-                            <yAxis>
-                                <NumberAxis side="LEFT" minorTickVisible="false" />
-                            </yAxis>
-                        </LineChart>
                         <AnchorPane fx:id="monitorAnchor" minHeight="0.0" minWidth="0.0" mouseTransparent="true" />
                     </children>
                 </StackPane>

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -66,7 +66,7 @@
                             <children>
                                 <StackedAreaChart fx:id="topNChart" animated="false" legendVisible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis fx:id="topNYAxis" autoRanging="false" label="MB" side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
@@ -66,7 +66,7 @@
                             <children>
                                 <StackedAreaChart fx:id="topNChart" animated="false" legendVisible="false" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis fx:id="topNYAxis" autoRanging="false" label="MB" side="LEFT" minorTickVisible="false" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (C) 2015 Nippon Telegraph and Telephone Corporation
+ Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
 
  This program is free software; you can redistribute it and/or
  modify it under the terms of the GNU General Public License
@@ -46,7 +46,7 @@
                             <children>
                                 <StackedAreaChart id="heapChart" fx:id="heapChart" animated="false" createSymbols="false" layoutX="-129.0" layoutY="-91.0" minHeight="0.0" title="%chart.javaheap" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" />
@@ -59,7 +59,7 @@
                             <children>
                                 <LineChart id="instanceChart" fx:id="instanceChart" animated="false" createSymbols="false" layoutX="-149.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.instances" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" visible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" visible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="instances" side="LEFT" />
@@ -72,7 +72,7 @@
                             <children>
                                 <LineChart id="gcTimeChart" fx:id="gcTimeChart" animated="false" createSymbols="false" layoutX="-169.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.gctime" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="ms" side="LEFT" />
@@ -85,7 +85,7 @@
                             <children>
                                 <AreaChart id="metaspaceChart" fx:id="metaspaceChart" animated="false" createSymbols="false" layoutX="-174.0" layoutY="-166.0" minHeight="0.0" title="%chart.metaspace" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <CategoryAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" />

--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/summary.fxml
@@ -46,7 +46,7 @@
                             <children>
                                 <StackedAreaChart id="heapChart" fx:id="heapChart" animated="false" createSymbols="false" layoutX="-129.0" layoutY="-91.0" minHeight="0.0" title="%chart.javaheap" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />
@@ -59,7 +59,7 @@
                             <children>
                                 <LineChart id="instanceChart" fx:id="instanceChart" animated="false" createSymbols="false" layoutX="-149.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.instances" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" visible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" visible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="instances" side="LEFT" minorTickVisible="false" />
@@ -72,7 +72,7 @@
                             <children>
                                 <LineChart id="gcTimeChart" fx:id="gcTimeChart" animated="false" createSymbols="false" layoutX="-169.0" layoutY="-120.0" legendVisible="false" minHeight="0.0" title="%chart.gctime" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="ms" side="LEFT" minorTickVisible="false" />
@@ -85,7 +85,7 @@
                             <children>
                                 <AreaChart id="metaspaceChart" fx:id="metaspaceChart" animated="false" createSymbols="false" layoutX="-174.0" layoutY="-166.0" minHeight="0.0" title="%chart.metaspace" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                                     <xAxis>
-                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" tickMarkVisible="false" autoRanging="false" />
+                                        <NumberAxis side="BOTTOM" tickLabelsVisible="false" minorTickVisible="false" autoRanging="false" />
                                     </xAxis>
                                     <yAxis>
                                         <NumberAxis label="MB" side="LEFT" minorTickVisible="false" />


### PR DESCRIPTION
THIS PR IS NOT JUST A PULL-REQUEST! I WANT TO START TO DISCUSS FROM THIS PR!!

I've working for migration to NumberAxis to draw time-awareness charts in [Bug 3194](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3194) and PR #40 .
I've heard the comment that we should continue to provide CategoryAxis version because some users still want to use the accustomed way.

I implemented CategoryAxis and NumberAxis on charts on Log Resource tab. You can select `x_numberaxis` in `heapstats.conf` . If you set it to `true`, all charts in Log Resource tab will be drawn with `NumberAxis` . Otherwise, they will be drawn with `CategoryAxis` .

However, I cannot implement it to SnapShot tab and cannot move forward this PR.
I guess this implementation is too complex.

For example, we have to remove definitions about all XYCharts from FXML, and we need to add custom `ControllerFactory` . I added base class for drawing charts and two sub class for special processing of `NumberAxis` and `CategoryAxis` . I'm not certain this is right. If this PR is too complex and difficult to maintainance, I will propose `NumberAxis` only version (it means #40 ).

Before implementing it for SnapShot tab, I want to discuss.
Please help!!
