### PR TITLE
Bug 3225: JVM may hang when deadlock detector and safepoint are conflicted

### DIFF
--- a/agent/src/heapstats-engines/deadlockFinder.cpp
+++ b/agent/src/heapstats-engines/deadlockFinder.cpp
@@ -358,6 +358,17 @@ int TDeadlockFinder::checkDeadlock(jobject monitor, TDeadlockList **list) {
   }
 
   if (*status == THREAD_IN_VM) {
+    /*
+     * Reset "_thread_state".
+     *
+     * CAUTION!!
+     *   According to the comment of Monitor::lock_without_safepoint_check() in
+     *   hotspot/src/share/vm/runtime/mutex.cpp:
+     *     If this is called with thread state set to be in VM, the safepoint
+     *     synchronization code will deadlock!
+     */
+    *status = original_status;
+
     bool needLock = !vmFunc->MonitorOwnedBySelf(thread_lock);
 
     /*
@@ -373,8 +384,6 @@ int TDeadlockFinder::checkDeadlock(jobject monitor, TDeadlockList **list) {
       }
     }
 
-    /* Reset "_thread_state". */
-    *status = original_status;
     /* Reset "_safepoint_state". */
     vmFunc->ThreadSafepointStateDestroy(thisThreadPtr);
     vmFunc->ThreadSafepointStateCreate(thisThreadPtr);


### PR DESCRIPTION
This PR is for [Bug 3225](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3225) .
Please review it!