### PR TITLE
Bug 3261: Cannot start FXAnalyzer when HeapStatsFXAnalyzer.main() is called directly

### DIFF
--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/WindowController.java
@@ -299,12 +299,12 @@ public class WindowController implements Initializable {
 
         try(DirectoryStream<Path> jarPaths = Files.newDirectoryStream(libPath, "*.jar")){
             jarURLList = StreamSupport.stream(jarPaths.spliterator(), false)
-                    .map(new FunctionWrapper<>(p -> p.toUri().toURL()))
-                    .filter(u -> !u.getFile().endsWith("heapstats-core.jar"))
-                    .filter(u -> !u.getFile().endsWith("heapstats-mbean.jar"))
-                    .filter(u -> !u.getFile().endsWith("jgraphx.jar"))
-                    .collect(Collectors.toList())
-                    .toArray(new URL[0]);
+                                      .map(new FunctionWrapper<>(p -> p.toUri().toURL()))
+                                      .filter(u -> !u.getFile().endsWith("heapstats-core.jar"))
+                                      .filter(u -> !u.getFile().endsWith("heapstats-mbean.jar"))
+                                      .filter(u -> !u.getFile().endsWith("jgraphx.jar"))
+                                      .collect(Collectors.toList())
+                                      .toArray(new URL[0]);
         }
         catch(IOException ex) {
             Logger.getLogger(WindowController.class.getName()).log(Level.SEVERE, null, ex);

--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/utils/HeapStatsUtils.java
@@ -72,7 +72,7 @@ public class HeapStatsUtils {
             String appJar = Stream.of(System.getProperty("java.class.path").split(System.getProperty("path.separator")))
                     .filter(s -> s.endsWith("heapstats-analyzer.jar"))
                     .findFirst()
-                    .get();
+                    .orElse(".");
             currentPath = Paths.get(appJar).toAbsolutePath().getParent();
         }
 
@@ -96,7 +96,7 @@ public class HeapStatsUtils {
         }
 
         /* Load resource bundle */
-        resource = ResourceBundle.getBundle("HeapStatsResources", new Locale(prop.getProperty("language")));
+        resource = ResourceBundle.getBundle("HeapStatsResources");
 
         /* Validate values in properties. */
 
@@ -107,6 +107,9 @@ public class HeapStatsUtils {
         } else if (!language.equals("en") && !language.equals("ja")) {
             throw new HeapStatsConfigException(resource.getString("invalid.option") + " language=" + language);
         }
+
+        /* Load resource bundle again */
+        resource = ResourceBundle.getBundle("HeapStatsResources", new Locale(prop.getProperty("language")));
 
         /* RankLevel */
         String rankLevelStr = prop.getProperty("ranklevel");


### PR DESCRIPTION
This PR is for [Bug 3261](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3261).
Please review it.