### PR TITLE
Bug 3252: HeapStats CLI should dump envInfo

### DIFF
--- a/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
+++ b/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2015 Yasumasa Suenaga
+ * Copyright (C) 2014-2016 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -326,6 +326,11 @@ public class ArchiveData {
         try(ZipFile archive = new ZipFile(archivePath)){
             archive.stream().forEach(new ConsumerWrapper<ZipEntry>(d -> processZipEntry(archive, d)));
             buildSockData();
+            List<String> envInfoStrings = envInfo.entrySet()
+                                                 .stream()
+                                                 .map(e -> e.getKey() + " = " + e.getValue())
+                                                 .collect(Collectors.toList());
+            Files.write(Paths.get(extractPath.getAbsolutePath(), "envInfo.txt"), envInfoStrings, StandardOpenOption.CREATE);
         }
         
         parsed = true;


### PR DESCRIPTION
This PR is for [Bug 3252](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3252).
Please review it.