### PR TITLE
Bug 3265: Many WARN and CRIT messages are shown when DumpRequest is sent

### DIFF
--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -212,7 +212,7 @@ OVERRIDE_ADJ_DEFINE(adj, 7, 3)
 /* for JVMTI IterateOverHeap. */
 
 /* IterateOverHeapObjectClosure::do_object(oop o) */
-OVERRIDE_DEFINE_WITHOUT_PERMCHECK(jvmti, 0, 2)
+OVERRIDE_DEFINE(jvmti, 0, 2)
 
 /* For inner GC start. */
 


### PR DESCRIPTION
This PR is for [Bug 3265](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3265).

A HeapStats user reports that when he send `SIGQUIT` to JVM, HeapStats Agent shows many warning/critical messages to stderr as below:

```
heapstats WARN: Couldn't get class name!
heapstats CRIT: Couldn't get ObjectData!
```

He uses JDK 7.

It causes that hookpoint of JVMTI [IterateOverHeap](https://docs.oracle.com/javase/8/docs/platform/jvmti/jvmti.html#IterateOverHeap) does not check `oop` whether it located at PermGen. So HeapStats Agent try to get class name from `KlassOop`.

We should skip hook function when `oop` is located at PermGen.

Please review it.