### PR TITLE
Bug 3266 : 'make install' failed 

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,8 @@ SUBDIRS = agent mbean
 MVN = @MVN@
 JAVA_HOME = @JDK_DIR@
 
-ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-2.0-bin/heapstats-analyzer-2.0
-CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-2.0-bin/heapstats-cli-2.0
+ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-$(PACKAGE_VERSION)-bin/heapstats-analyzer-$(PACKAGE_VERSION)
+CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-$(PACKAGE_VERSION)-bin/heapstats-cli-$(PACKAGE_VERSION)
 
 .PHONY: $(SUBDIRS) analyzer
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -322,8 +322,8 @@ top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I ./m4
 SUBDIRS = agent mbean
 JAVA_HOME = @JDK_DIR@
-ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-2.0-bin/heapstats-analyzer-2.0
-CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-2.0-bin/heapstats-cli-2.0
+ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-$(PACKAGE_VERSION)-bin/heapstats-analyzer-$(PACKAGE_VERSION)
+CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-$(PACKAGE_VERSION)-bin/heapstats-cli-$(PACKAGE_VERSION)
 all: all-recursive
 
 .SUFFIXES:


### PR DESCRIPTION
Fixed that Bug 3266 - 'make install' failed because the version in a directory path mismatch.
http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3266

Change the version of install source directories from fixed value to "${PACKAGE_VERSION}" .