### PR TITLE
Bug 3269: Could not attach HeapStats Agent to JDK 6

### DIFF
--- a/agent/src/heapstats-engines/vmFunctions.cpp
+++ b/agent/src/heapstats-engines/vmFunctions.cpp
@@ -171,8 +171,12 @@ bool TVMFunctions::getFunctionsFromSymbol(void) {
   /* Search "UserHandler" function symbol. */
   userHandler = (TUserHandler) this->symFinder->findSymbol(USERHANDLER_SYMBOL);
   if (unlikely(userHandler == NULL)) {
-    logger->printWarnMsg("UserHandler() not found.");
-    return false;
+    userHandler = (TUserHandler) this->symFinder->findSymbol(
+                                                       USERHANDLER_SYMBOL_JDK6);
+    if (unlikely(userHandler == NULL)) {
+      logger->printWarnMsg("UserHandler() not found.");
+      return false;
+    }
   }
 
   /* Search "SR_handler" function symbol. */
@@ -181,8 +185,12 @@ bool TVMFunctions::getFunctionsFromSymbol(void) {
     sr_handler = (TSR_Handler) this->symFinder->findSymbol(
                                                     SR_HANDLER_SYMBOL_FALLBACK);
     if (sr_handler == NULL) {
-      logger->printWarnMsg("SR_handler() not found.");
-      return false;
+      sr_handler = (TSR_Handler) this->symFinder->findSymbol(
+                                                        SR_HANDLER_SYMBOL_JDK6);
+      if (sr_handler == NULL) {
+        logger->printWarnMsg("SR_handler() not found.");
+        return false;
+      }
     }
   }
 

--- a/agent/src/heapstats-engines/vmFunctions.hpp
+++ b/agent/src/heapstats-engines/vmFunctions.hpp
@@ -111,12 +111,14 @@
  * \brief Symbol of UserHandler()
  */
 #define USERHANDLER_SYMBOL "_ZL11UserHandleriPvS_"
+#define USERHANDLER_SYMBOL_JDK6 "_Z11UserHandleriPvS_"
 
 /*!
  * \brief Symbol of SR_handler()
  */
 #define SR_HANDLER_SYMBOL          "_ZL10SR_handleriP7siginfoP8ucontext"
 #define SR_HANDLER_SYMBOL_FALLBACK "_ZL10SR_handleriP9siginfo_tP8ucontext"
+#define SR_HANDLER_SYMBOL_JDK6     "_Z10SR_handleriP7siginfoP8ucontext"
 
 /*!
  * \brief Symbol of ObjectSynchronizer::get_lock_owner().


### PR DESCRIPTION
HeapStats Agent cannot be attached to JDK 6 as below:

```
$ /usr/local/jdk1.6.0_45/bin/java -agentpath:/home/yasuenag/github/heapstats/agent/src/libheapstats-2.0.so.3 LongSleep
heapstats WARN: Could not open configuration file: /usr/local/etc/heapstats.conf cause: No such file or directory
heapstats INFO: HeapStats 2.0.trunk
heapstats INFO: Supported processor features: AVX
heapstats WARN: UserHandler() not found.
heapstats CRIT: Cannot initialize TVMFunctions.
heapstats CRIT: Cannot get TVMFunctions instance.
*** Error in `/usr/local/jdk1.6.0_45/bin/java': corrupted double-linked list: 0x00007f7c480289a0 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x7925b)[0x7f7c4f85825b]
/lib64/libc.so.6(+0x82f72)[0x7f7c4f861f72]
/lib64/libc.so.6(cfree+0x4c)[0x7f7c4f86531c]
/home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so(_Z17oopUtilInitializeP9_jvmtiEnv+0x1ea)[0x7f7c4d466d3a]
/home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so(_Z22onAgentInitForSnapShotP9_jvmtiEnv+0xf)[0x7f7c4d47adff]
/home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so(_Z20CommonInitializationP7JavaVM_PP9_jvmtiEnvPc+0x1eb)[0x7f7c4d463dfb]
/home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so(Agent_OnLoad+0x24)[0x7f7c4d463fb4]
/usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so(+0x82122f)[0x7f7c4f3f022f]
/usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so(+0x8210ea)[0x7f7c4f3f00ea]
/usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so(JNI_CreateJavaVM+0x80)[0x7f7c4f0eb800]
/usr/local/jdk1.6.0_45/bin/java[0x400035f8]
/usr/local/jdk1.6.0_45/bin/java(JavaMain+0x6e)[0x4000206e]
/lib64/libpthread.so.0(+0x76ca)[0x7f7c4fdb06ca]
/lib64/libc.so.6(clone+0x5f)[0x7f7c4f8e6f6f]
======= Memory map: ========
40000000-40009000 r-xp 00000000 08:11 2232957                            /usr/local/jdk1.6.0_45/bin/java
40108000-4010a000 rwxp 00008000 08:11 2232957                            /usr/local/jdk1.6.0_45/bin/java
41103000-41124000 rwxp 00000000 00:00 0                                  [heap]
7f7c40000000-7f7c40021000 rwxp 00000000 00:00 0 
7f7c40021000-7f7c44000000 ---p 00000000 00:00 0 
7f7c48000000-7f7c48091000 rwxp 00000000 00:00 0 
7f7c48091000-7f7c4c000000 ---p 00000000 00:00 0 
7f7c4d405000-7f7c4d589000 r-xp 00000000 08:03 24121278                   /home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so
7f7c4d589000-7f7c4d789000 ---p 00184000 08:03 24121278                   /home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so
7f7c4d789000-7f7c4d79e000 r-xp 00184000 08:03 24121278                   /home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so
7f7c4d79e000-7f7c4d7a8000 rwxp 00199000 08:03 24121278                   /home/yasuenag/github/heapstats/agent/src/heapstats-engines/libheapstats-engine-avx-2.0.so
7f7c4d7a8000-7f7c4d7ae000 rwxp 00000000 00:00 0 
7f7c4d7ae000-7f7c4d7c4000 r-xp 00000000 08:11 13894462                   /usr/lib64/libgcc_s-6.2.1-20160916.so.1
7f7c4d7c4000-7f7c4d9c3000 ---p 00016000 08:11 13894462                   /usr/lib64/libgcc_s-6.2.1-20160916.so.1
7f7c4d9c3000-7f7c4d9c4000 r-xp 00015000 08:11 13894462                   /usr/lib64/libgcc_s-6.2.1-20160916.so.1
7f7c4d9c4000-7f7c4d9c5000 rwxp 00016000 08:11 13894462                   /usr/lib64/libgcc_s-6.2.1-20160916.so.1
7f7c4d9c5000-7f7c4db3d000 r-xp 00000000 08:11 13899334                   /usr/lib64/libstdc++.so.6.0.22
7f7c4db3d000-7f7c4dd3d000 ---p 00178000 08:11 13899334                   /usr/lib64/libstdc++.so.6.0.22
7f7c4dd3d000-7f7c4dd47000 r-xp 00178000 08:11 13899334                   /usr/lib64/libstdc++.so.6.0.22
7f7c4dd47000-7f7c4dd49000 rwxp 00182000 08:11 13899334                   /usr/lib64/libstdc++.so.6.0.22
7f7c4dd49000-7f7c4dd4d000 rwxp 00000000 00:00 0 
7f7c4dd4d000-7f7c4dd62000 r-xp 00000000 08:11 13901470                   /usr/lib64/libz.so.1.2.8
7f7c4dd62000-7f7c4df61000 ---p 00015000 08:11 13901470                   /usr/lib64/libz.so.1.2.8
7f7c4df61000-7f7c4df62000 r-xp 00014000 08:11 13901470                   /usr/lib64/libz.so.1.2.8
7f7c4df62000-7f7c4df63000 rwxp 00015000 08:11 13901470                   /usr/lib64/libz.so.1.2.8
7f7c4df63000-7f7c4df65000 r-xp 00000000 08:03 24121282                   /home/yasuenag/github/heapstats/agent/src/libheapstats-2.0.so.3
7f7c4df65000-7f7c4e164000 ---p 00002000 08:03 24121282                   /home/yasuenag/github/heapstats/agent/src/libheapstats-2.0.so.3
7f7c4e164000-7f7c4e165000 r-xp 00001000 08:03 24121282                   /home/yasuenag/github/heapstats/agent/src/libheapstats-2.0.so.3
7f7c4e165000-7f7c4e166000 rwxp 00002000 08:03 24121282                   /home/yasuenag/github/heapstats/agent/src/libheapstats-2.0.so.3
7f7c4e166000-7f7c4e17c000 r-xp 00000000 08:11 13900622                   /usr/lib64/libnsl-2.24.so
7f7c4e17c000-7f7c4e37b000 ---p 00016000 08:11 13900622                   /usr/lib64/libnsl-2.24.so
7f7c4e37b000-7f7c4e37c000 r-xp 00015000 08:11 13900622                   /usr/lib64/libnsl-2.24.so
7f7c4e37c000-7f7c4e37d000 rwxp 00016000 08:11 13900622                   /usr/lib64/libnsl-2.24.so
7f7c4e37d000-7f7c4e37f000 rwxp 00000000 00:00 0 
7f7c4e37f000-7f7c4e3a8000 r-xp 00000000 08:11 5639578                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libjava.so
7f7c4e3a8000-7f7c4e4a7000 ---p 00029000 08:11 5639578                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libjava.so
7f7c4e4a7000-7f7c4e4ae000 rwxp 00028000 08:11 5639578                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libjava.so
7f7c4e4ae000-7f7c4e4bb000 r-xp 00000000 08:11 5639560                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libverify.so
7f7c4e4bb000-7f7c4e5ba000 ---p 0000d000 08:11 5639560                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libverify.so
7f7c4e5ba000-7f7c4e5bd000 rwxp 0000c000 08:11 5639560                    /usr/local/jdk1.6.0_45/jre/lib/amd64/libverify.so
7f7c4e5bd000-7f7c4e5c4000 r-xp 00000000 08:11 13900735                   /usr/lib64/librt-2.24.so
7f7c4e5c4000-7f7c4e7c3000 ---p 00007000 08:11 13900735                   /usr/lib64/librt-2.24.so
7f7c4e7c3000-7f7c4e7c4000 r-xp 00006000 08:11 13900735                   /usr/lib64/librt-2.24.so
7f7c4e7c4000-7f7c4e7c5000 rwxp 00007000 08:11 13900735                   /usr/lib64/librt-2.24.so
7f7c4e7c5000-7f7c4e7c6000 ---p 00000000 00:00 0 
7f7c4e7c6000-7f7c4e8c6000 rwxp 00000000 00:00 0 
7f7c4e8c6000-7f7c4e9ce000 r-xp 00000000 08:11 13900601                   /usr/lib64/libm-2.24.so
7f7c4e9ce000-7f7c4ebcd000 ---p 00108000 08:11 13900601                   /usr/lib64/libm-2.24.so
7f7c4ebcd000-7f7c4ebce000 r-xp 00107000 08:11 13900601                   /usr/lib64/libm-2.24.so
7f7c4ebce000-7f7c4ebcf000 rwxp 00108000 08:11 13900601                   /usr/lib64/libm-2.24.so
7f7c4ebcf000-7f7c4f4ed000 r-xp 00000000 08:11 5639585                    /usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so
7f7c4f4ed000-7f7c4f5ef000 ---p 0091e000 08:11 5639585                    /usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so
7f7c4f5ef000-7f7c4f7a5000 rwxp 00920000 08:11 5639585                    /usr/local/jdk1.6.0_45/jre/lib/amd64/server/libjvm.so
7f7c4f7a5000-7f7c4f7df000 rwxp 00000000 00:00 0 
7f7c4f7df000-7f7c4f99c000 r-xp 00000000 08:11 13900472                   /usr/lib64/libc-2.24.so
7f7c4f99c000-7f7c4fb9b000 ---p 001bd000 08:11 13900472                   /usr/lib64/libc-2.24.so
7f7c4fb9b000-7f7c4fb9f000 r-xp 001bc000 08:11 13900472                   /usr/lib64/libc-2.24.so
7f7c4fb9f000-7f7c4fba1000 rwxp 001c0000 08:11 13900472                   /usr/lib64/libc-2.24.so
7f7c4fba1000-7f7c4fba5000 rwxp 00000000 00:00 0 
7f7c4fba5000-7f7c4fba8000 r-xp 00000000 08:11 13900572                   /usr/lib64/libdl-2.24.so
7f7c4fba8000-7f7c4fda7000 ---p 00003000 08:11 13900572                   /usr/lib64/libdl-2.24.so
7f7c4fda7000-7f7c4fda8000 r-xp 00002000 08:11 13900572                   /usr/lib64/libdl-2.24.so
7f7c4fda8000-7f7c4fda9000 rwxp 00003000 08:11 13900572                   /usr/lib64/libdl-2.24.so
7f7c4fda9000-7f7c4fdc1000 r-xp 00000000 08:11 13900712                   /usr/lib64/libpthread-2.24.so
7f7c4fdc1000-7f7c4ffc1000 ---p 00018000 08:11 13900712                   /usr/lib64/libpthread-2.24.so
7f7c4ffc1000-7f7c4ffc2000 r-xp 00018000 08:11 13900712                   /usr/lib64/libpthread-2.24.so
7f7c4ffc2000-7f7c4ffc3000 rwxp 00019000 08:11 13900712                   /usr/lib64/libpthread-2.24.so
7f7c4ffc3000-7f7c4ffc7000 rwxp 00000000 00:00 0 
7f7c4ffc7000-7f7c4ffec000 r-xp 00000000 08:11 13894850                   /usr/lib64/ld-2.24.so
7f7c500c2000-7f7c500c4000 rwxp 00000000 00:00 0 
7f7c500c4000-7f7c500cb000 r-xp 00000000 08:11 5639550                    /usr/local/jdk1.6.0_45/jre/lib/amd64/jli/libjli.so
7f7c500cb000-7f7c501cc000 ---p 00007000 08:11 5639550                    /usr/local/jdk1.6.0_45/jre/lib/amd64/jli/libjli.so
7f7c501cc000-7f7c501ce000 rwxp 00008000 08:11 5639550                    /usr/local/jdk1.6.0_45/jre/lib/amd64/jli/libjli.so
7f7c501e7000-7f7c501e9000 rwxp 00000000 00:00 0 
7f7c501e9000-7f7c501ea000 r-xp 00000000 00:00 0 
7f7c501ea000-7f7c501ec000 rwxp 00000000 00:00 0 
7f7c501ec000-7f7c501ed000 r-xp 00025000 08:11 13894850                   /usr/lib64/ld-2.24.so
7f7c501ed000-7f7c501ee000 rwxp 00026000 08:11 13894850                   /usr/lib64/ld-2.24.so
7f7c501ee000-7f7c501ef000 rwxp 00000000 00:00 0 
7ffc100ff000-7ffc10120000 rwxp 00000000 00:00 0                          [stack]
7ffc101f0000-7ffc101f2000 r--p 00000000 00:00 0                          [vvar]
7ffc101f2000-7ffc101f4000 r-xp 00000000 00:00 0                          [vdso]
ffffffffff600000-ffffffffff601000 r-xp 00000000 00:00 0                  [vsyscall]
Aborted (core dumped)
```

*THIS BUG APPEARS ON TRUNK REPOS ONLY*
This error appears from [Bug 2911](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=2911) (GitHub PR #25). These changes have not been merged to 2.0 repos.

I checked symbols in libjvm in JDK 6 to 8. Function symbols in JDK 6 are different from JDK 7 or later as below:

* UserHandler

```
$ nm jdk1.6.0_45/jre/lib/amd64/server/libjvm.so | grep UserHandler
0000000000713120 t _Z11UserHandleriPvS_
$ nm jdk1.8.0_112/jre/lib/amd64/server/libjvm.so | grep UserHandler
00000000009235d0 t _ZL11UserHandleriPvS_
$ nm jdk1.7.0_80/jre/lib/amd64/server/libjvm.so | grep UserHandler
00000000008210d0 t _ZL11UserHandleriPvS_
```

* SR_handler

```
$ nm jdk1.6.0_45/jre/lib/amd64/server/libjvm.so | grep SR_handler
0000000000713520 t _Z10SR_handleriP7siginfoP8ucontext
$ nm jdk1.7.0_80/jre/lib/amd64/server/libjvm.so | grep SR_handler
000000000081ffb0 t _ZL10SR_handleriP7siginfoP8ucontext
$ nm jdk1.8.0_112/jre/lib/amd64/server/libjvm.so | grep SR_handler
00000000009221d0 t _ZL10SR_handleriP7siginfoP8ucontext
```

We should add fallback code to JDK 6.