### PR TITLE
Bug 3279: Fix not to reference freed TChildCounter when SnapShot merges

### DIFF
--- a/agent/src/heapstats-engines/snapShotContainer.cpp
+++ b/agent/src/heapstats-engines/snapShotContainer.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file snapshotContainer.cpp
  * \brief This file is used to add up using size every class.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -477,15 +477,19 @@ void TSnapShotContainer::mergeChildren(void) {
            * reference to it from child object data.
            */
           if (objData->isRemoved) {
+            TChildClassCounter *nextCounter = counter->next;
+
             if (prevCounter == NULL) {
-              srcClsCounter->child = counter->next;
+              srcClsCounter->child = nextCounter;
             } else {
-              prevCounter->next = counter->next;
+              prevCounter->next = nextCounter;
             }
 
             /* Deallocate TChildClassCounter. */
             free(counter->counter);
             free(counter);
+
+            counter = nextCounter;
           } else {
             /* Search child class. */
             TChildClassCounter *childClsData =
@@ -502,9 +506,8 @@ void TSnapShotContainer::mergeChildren(void) {
             }
 
             prevCounter = counter;
+            counter = counter->next;
           }
-
-          counter = counter->next;
         }
       }
     }


### PR DESCRIPTION
This issue is for IcedTea Bugzilla [Bug 3279](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3279).

We've fixed bug about unloaded `TObjectData` in [Bug 3104](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3104) (issue #31 ).
However, this fix is unsufficient.

We should fix not to referent free'ed `TChildClassCounter`.

AFAIK, unloaded `TObjectData` and their `TChildClassCounter` will be handled in `TSnapShotContainer::mergeChildren()`. So I think this issuen will not occur in another place.