### PR TITLE
Bug 3285: JVM aborted on assert code at MonitorContended JVMTI event

### DIFF
--- a/agent/heapstats.conf.in
+++ b/agent/heapstats.conf.in
@@ -18,7 +18,9 @@ trigger_on_fullgc=true
 trigger_on_dump=true
 
 # deadlock check
-check_deadlock=true
+# This feature is experimental. It might be a cause of HotSpot internal error
+# when you set this flag to true.
+check_deadlock=false
 
 # Trigger logging setting
 trigger_on_logerror=true

--- a/agent/src/heapstats-engines/configuration.cpp
+++ b/agent/src/heapstats-engines/configuration.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file configuration.cpp
  * \brief This file treats HeapStats configuration.
- * Copyright (C) 2014-2016 Yasumasa Suenaga
+ * Copyright (C) 2014-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -94,7 +94,7 @@ void TConfiguration::initializeConfig(const TConfiguration *src) {
                                          &setOnewayBooleanValue);
     triggerOnDump = new TBooleanConfig(this, "trigger_on_dump", true,
                                        &setOnewayBooleanValue);
-    checkDeadlock = new TBooleanConfig(this, "check_deadlock", true,
+    checkDeadlock = new TBooleanConfig(this, "check_deadlock", false,
                                        &setOnewayBooleanValue);
     triggerOnLogError = new TBooleanConfig(this, "trigger_on_logerror", true,
                                            &setOnewayBooleanValue);
@@ -462,7 +462,7 @@ void TConfiguration::printSetting(void) {
                        triggerOnDump->get() ? "true" : "false");
 
   /* Output status of deadlock check. */
-  logger->printInfoMsg("Deadlock check = %s",
+  logger->printInfoMsg("Deadlock check (experimental feature) = %s",
                        checkDeadlock->get() ? "true" : "false");
 
   /* Output status of logging triggers. */

--- a/agent/src/heapstats-engines/logMain.cpp
+++ b/agent/src/heapstats-engines/logMain.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file logmain.cpp
  * \brief This file is used common logging process.
- * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -317,7 +317,7 @@ void setThreadEnableForLog(jvmtiEnv *jvmti, JNIEnv *env, bool enable) {
     flagLogSignal = 0;
     flagAllLogSignal = 0;
 
-    if (conf->TriggerOnLogLock()->get() && !abortionByDeadlock) {
+    if (conf->CheckDeadlock()->get() && !abortionByDeadlock) {
       /* Switch deadlock finder state. */
       if (enable) {
         TDeadlockFinder::getInstance()->start(jvmti, env);


### PR DESCRIPTION
This PR is for [Bug 3285](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3285).

HeapStats user reports crash case as below:

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (safepoint.cpp:691), pid=7013, tid=0x00007f70dad1f700
#  fatal error: Deadlock in safepoint code.  Should have called back to the VM before blocking.
#
# JRE version: OpenJDK Runtime Environment (8.0_101-b13) (build 1.8.0_101-b13)
# Java VM: OpenJDK 64-Bit Server VM (25.101-b13 mixed mode linux-amd64 compressed oops)
```

I checked JVM (HotSpot) and HeapStats agent code, and I found a problem on HeapStats.

HeapStats deadlock detector will change thread state from `thread_in_vm` to `thread_in_native` because internal function in HotSpot which is used by HeapStats changes `thread_in_vm`.

JVMTI callback functions will be called `thread_in_native`. So we have to set `thread_in_native` when our callback functions are returned.
However, when safepoint state is `synchronizing`, `_safepoint_state` of the threads which thread state is `thread_in_vm` will be set to `_call_back`. That is cause of this assert code.

We cannot avoid these state change, and cannot avoid safepoint synchronizing.
So I propose that we mark deadlock detector to *EXPERIMENTAL FEATURE*.
And we should work for this feature. I have plan to refactor.

We will migrate deadlock detector to *PRODUCTION FEATURE* after this work.