### PR TITLE
Bug 3284: HeapStats Agent might crash when object children are scanned

### DIFF
--- a/agent/src/heapstats-engines/arch/arm/util.inline.hpp
+++ b/agent/src/heapstats-engines/arch/arm/util.inline.hpp
@@ -1,0 +1,42 @@
+/*!
+ * \file util.inline.hpp
+ * \brief Optimized utility functions for ARM processor.
+ * Copyright (C) 2017 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef ARM_UTIL_H
+#define ARM_UTIL_H
+
+inline void atomic_inc(int *target, int value) {
+  asm volatile("1:"
+               "  ldrex %%r0, [%0];"
+               "  add %%r0, %%r0, %1;"
+               "  strex %%r1, %%r0, [%0];"
+               "  tst %%r1, %%r1;"
+               "  bne 1b;"
+               : : "r"(target), "r"(value) : "memory", "cc", "%r0", "%r1");
+}
+
+inline int atomic_get(int *target) {
+  register int ret;
+  asm volatile("ldrex %0, [%1]" : "=r"(ret) : "r"(target) : );
+
+  return ret;
+}
+
+#endif  // ARM_UTIL_H

--- a/agent/src/heapstats-engines/arch/x86/util.inline.hpp
+++ b/agent/src/heapstats-engines/arch/x86/util.inline.hpp
@@ -1,0 +1,46 @@
+/*!
+ * \file util.inline.hpp
+ * \brief Optimized utility functions for x86 processor.
+ * Copyright (C) 2017 Yasumasa Suenaga
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ */
+
+#ifndef X86_UTIL_H
+#define X86_UTIL_H
+
+inline void atomic_inc(int *target, int value) {
+  asm volatile("lock addl %1, (%0)" :
+                                    : "r"(target), "r"(value)
+                                    : "memory", "cc");
+}
+
+/*
+ * We can use MOV operation at this point.
+ * LOCK'ed store operation will be occurred before load (MOV) operation.
+ *
+ * Intel (R)  64 and IA-32 Architectures Software Developer’s Manual
+ *   Volume 3A: System Programming Guide, Part 1
+ *     8.2.3.8 Locked Instructions Have a Total Order
+ */
+inline int atomic_get(int *target) {
+  register int ret;
+  asm volatile("movl (%1), %0" : "=r"(ret) : "r"(target) : );
+
+  return ret;
+}
+
+#endif  // X86_UTIL_H

--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -980,7 +980,8 @@ void TClassContainer::commitClassChange(void) {
         TObjectData *objData = (*cur).second;
 
         /* If class is prepared remove from class container. */
-        if (unlikely(objData->oldTotalSize == 0 && objData->isRemoved)) {
+        if (unlikely(objData->isRemoved &&
+                     (atomic_get(&objData->numRefsFromChildren) == 0))) {
           /*
            * If we do removing map item here,
            * iterator's relationship will be broken.

--- a/agent/src/heapstats-engines/snapShotMain.cpp
+++ b/agent/src/heapstats-engines/snapShotMain.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file snapShotMain.cpp
  * \brief This file is used to take snapshot.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -378,7 +378,12 @@ void iterateFieldObjectCallBack(void *oop, void *data) {
     TObjectData *clsData =
         getObjectDataFromKlassOop(localClsContainer, klassOop);
     /* Push new child loaded class. */
-    clsCounter = localSnapshot->pushNewChildClass(parentCounter, clsData);
+    if (!clsData->isRemoved) {
+      clsCounter = localSnapshot->pushNewChildClass(parentCounter, clsData);
+    } else {
+      /* We should return if clsData has already been removed (unloaded). */
+      return;
+    }
   }
 
   if (unlikely(clsCounter == NULL)) {

--- a/agent/src/heapstats-engines/util.hpp
+++ b/agent/src/heapstats-engines/util.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file util.hpp
  * \brief This file is utilities.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -368,6 +368,14 @@ class TNumericalHasher {
 };
 
 /* CPU Specific utilities. */
+#if PROCESSOR_ARCH == X86
+#include "arch/x86/util.inline.hpp"
+#elif PROCESSOR_ARCH == ARM
+#include "arch/arm/util.inline.hpp"
+#else
+#error "Unknown CPU architecture."
+#endif
+
 #ifdef AVX
 #include "arch/x86/avx/util.hpp"
 #elif defined(SSE2) || defined(SSE3) || defined(SSE4)


### PR DESCRIPTION
This PR is for [Bug 3284](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3284).

HeapStats user reports crash case as below:

```
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007f2c7f460efd, pid=27703, tid=0x00007f2c7c366700
#
# JRE version: OpenJDK Runtime Environment (8.0_101-b13) (build 1.8.0_101-b13)
# Java VM: OpenJDK 64-Bit Server VM (25.101-b13 mixed mode linux-amd64 compressed oops)
# Problematic frame:
# C  [libheapstats-engine-avx-2.0.so+0x44efd]  iterateFieldObjectCallBack(void*, void*)+0x7d
```

I checked core image, and I found illegal value at crash point as below:

```
#7  0x00007f2c7f460efd in TSnapShotContainer::findChildClass (klassOop=0x7fcc818
28, clsCounter=0x7f2c382befa0, this=0x7f2c382ace10) at snapShotContainer.hpp:277

(gdb) p *counter
$1 = {counter = 0x7f2c381befa0, objData = 0x7f2c58336930, next = 0x0, callCount = 0}
(gdb) p *counter->objData
Cannot access memory at address 0x7f2c58336930
(gdb) p *prevCounter->objData
$3 = {tag = 139826116661104, classNameLen = 139826083173696, className = 0x0, klassOop = 0x21, oldTotalSize = 139826085441440, oopType = 3422552184, clsLoaderId = 6665789275947, clsLoaderTag = 360777252864, isRemoved = false, instanceSize = 3155905424834691072}
(gdb) p *morePrevCounter->objData
$4 = {tag = 139826083106800, classNameLen = 56, className = 0x7f2bcc039040 "Lsun/reflect/GeneratedSerializationConstructorAccessor8;", klassOop = 0x7f8493828, oldTotalSize = 16, oopType = otInstance, clsLoaderId = 29706614384, clsLoaderTag = 139828995367600, isRemoved = false, instanceSize = 16}

```

`prevCounter` has illegal objData. For example, `classNameLen` is very long value, and `oopType` has illegal value.
OTOH `morePrevCounter` seems to have valid data.

I guess the cause of this crash is free'ed memory access.
Currentry (after Bug 3279) `TSnapShotContainer::mergeChildren()` will remove all children data which is marked `isRemoved` .
However, HeapStats agent will have multiple TSnapShotContainer instance. They are not processed (including parent (master) container: HeapStats SnapShot will be available in TLS of each GC worker).

So we have to remove all children data on the memory.