### PR TITLE
Bug 3288: collect_reftree option does not affect oop scan

### DIFF
--- a/agent/src/heapstats-engines/snapShotMain.cpp
+++ b/agent/src/heapstats-engines/snapShotMain.cpp
@@ -473,7 +473,7 @@ inline void calculateObjectUsage(TSnapShotContainer *snapshot, void *oop) {
   localSnapshot->FastInc(clsCounter->counter, size);
 
   /* If we should not collect reftree or oop has no field. */
-  if (!conf->ReduceSnapShot()->get() || !hasOopField(oopType)) {
+  if (!conf->CollectRefTree()->get() || !hasOopField(oopType)) {
     return;
   }
 


### PR DESCRIPTION
This PR is for [Bug 3288](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3288).

Since HeapStats 2.0, `collect_reftree` option is available in `heapstats.conf`.
This option provides whether user want to collect reference data.

However this option just affects SnapShot file dump.
This option should affect oop scan phase on GC cycle.