### PR TITLE
Bug 3251: HeapStats Analyzer cannot extract zip archive when CSV has just one entry

### DIFF
--- a/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
+++ b/analyzer/fx/src/main/java/jp/co/ntt/oss/heapstats/plugin/builtin/log/tabs/LogResourcesController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2016 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2015-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -647,6 +647,19 @@ public class LogResourcesController implements Initializable {
         }
 
         private void setChartData() {
+            
+            if(targetLogData.isEmpty() || targetDiffData.isEmpty()){
+                Stream.of(javaMemoryChart, threadChart)
+                      .flatMap(c -> c.getData().stream())
+                      .forEach(s -> s.getData().clear());
+                Stream.of(javaCPUChart, systemCPUChart, safepointChart, safepointTimeChart, monitorChart)
+                      .flatMap(c -> c.getData().stream())
+                      .forEach(s -> s.getData().clear());
+                procSummary.getItems().clear();
+                suspectList = null;
+                return;
+            }
+            
             /* Set chart range */
             long startLogEpoch = targetLogData.get(0).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();
             long endLogEpoch = targetLogData.get(targetLogData.size() - 1).getDateTime().atZone(ZoneId.systemDefault()).toEpochSecond();


### PR DESCRIPTION
This PR is for [Bug 3251](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3251).

HeapStats analyzer cannot parse single (one entry) data in resource CSV file because it calculates diff data.
However, HeapStats agent might dump zip archive before logging interval. If so, we need to use CLI.

Many user like GUI tools. So I want to support this pattern.