### PR TITLE
Bug 3294: Reference counter should be handled in TClassContainer::allClear()

### DIFF
--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -373,9 +373,12 @@ void TClassContainer::allClear(void) {
          ++cur) {
       TObjectData *pos = (*cur).second;
 
-      if (likely(pos != NULL)) {
-        free(pos->className);
-        free(pos);
+      if (pos != NULL) {
+        atomic_inc(&pos->numRefsFromChildren, -1);
+        if (atomic_get(&pos->numRefsFromChildren) == 0) {
+          free(pos->className);
+          free(pos);
+        }
       }
     }
 


### PR DESCRIPTION
This PR is for [Bug 3294](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3294).

We've added reference counter of `TObjectData` on [Bug 3284](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3284) (PR #74 ) to track memory references. However it is not handled in `TClassContainer::allClaer()` .

This issue affects in HeapStats 1.1 or later.
We should fix it.