### PR TITLE
 Bug 3295: Incorrect condition for removing TObjectData instance

### DIFF
--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -373,12 +373,9 @@ void TClassContainer::allClear(void) {
          ++cur) {
       TObjectData *pos = (*cur).second;
 
-      if (pos != NULL) {
-        atomic_inc(&pos->numRefsFromChildren, -1);
-        if (atomic_get(&pos->numRefsFromChildren) == 0) {
-          free(pos->className);
-          free(pos);
-        }
+      if ((pos != NULL) && (atomic_get(&pos->numRefsFromChildren) == 0)) {
+        free(pos->className);
+        free(pos);
       }
     }
 


### PR DESCRIPTION
This PR is for [Bug 3295](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3295).

We added code to remove `TObjectData` instance in `TClassContainer::allClear()` .
`numRefsFromChildren` means number of references from `TChildClassCounter` . So we should not decrement it in this function.