### PR TITLE
Bug 3296: Reference counter should manage TObjectData instance

### DIFF
--- a/agent/src/heapstats-engines/snapShotContainer.cpp
+++ b/agent/src/heapstats-engines/snapShotContainer.cpp
@@ -205,7 +205,7 @@ TSnapShotContainer::~TSnapShotContainer(void) {
       counter = counter->next;
 
       /* Deallocate TChildClassCounter. */
-      atomic_inc(&aCounter->objData->numRefsFromChildren, -1);
+      atomic_inc(&aCounter->objData->numRefs, -1);
       free(aCounter->counter);
       free(aCounter);
     }
@@ -300,7 +300,7 @@ TChildClassCounter *TSnapShotContainer::pushNewChildClass(
     return NULL;
   }
 
-  atomic_inc(&objData->numRefsFromChildren, 1);
+  atomic_inc(&objData->numRefs, 1);
   this->clearObjectCounter(newCounter->counter);
   newCounter->objData = objData;
 
@@ -481,7 +481,7 @@ void TSnapShotContainer::mergeChildren(void) {
            * TClassContainer::commitClassChange().
            */
           if (objData->isRemoved) {
-            atomic_inc(&objData->numRefsFromChildren, -1);
+            atomic_inc(&objData->numRefs, -1);
             TChildClassCounter *nextCounter = counter->next;
 
             if (prevCounter == NULL) {
@@ -501,7 +501,7 @@ void TSnapShotContainer::mergeChildren(void) {
                                     &childClsData, &parentPrevData,
                                     &parentMorePrevData);
             if (likely(childClsData != NULL)) {
-              atomic_inc(&objData->numRefsFromChildren, -1);
+              atomic_inc(&objData->numRefs, -1);
 
               if (parentPrevData == NULL) {
                 clsCounter->child = childClsData->next;

--- a/agent/src/heapstats-engines/snapShotContainer.hpp
+++ b/agent/src/heapstats-engines/snapShotContainer.hpp
@@ -79,7 +79,7 @@ typedef struct {
   jlong clsLoaderTag;      /*!< Class loader class tag.                       */
   bool isRemoved;          /*!< Class is already unloaded.                    */
   jlong instanceSize;      /*!< Class size if this class is instanceKlass.    */
-  int numRefsFromChildren; /*!< Number of references from TChildClassCounter. */
+  int numRefs;             /*!< Number of references.                         */
 } TObjectData;
 #pragma pack(pop)
 


### PR DESCRIPTION
TObjectData instance reuse memory pointer if possible to keep memory foot print lower.
So we should count references of TObjectData instance as well.

This patch will merge to HeapStats-1.1 and later repositories.