### PR TITLE
Bug 3309: JDK 9 crashes at Agent_OnUnload()

### DIFF
--- a/agent/src/heapstats-engines/libmain.cpp
+++ b/agent/src/heapstats-engines/libmain.cpp
@@ -662,7 +662,9 @@ JNIEXPORT void JNICALL Agent_OnUnload(JavaVM *vm) {
   loadConfigPath = NULL;
 
   /* Cleanup TTrapSender. */
-  TTrapSender::finalize();
+  if (conf->SnmpSend()->get()) {
+    TTrapSender::finalize();
+  }
 }
 
 /*!


### PR DESCRIPTION
This PR is for [Bug 3309](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3309).

After [Bug 3308](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3308) (PR #81), HeapStats with JDK 9 crashes at `TTrapSender::finalize()`.
We should avoid this function call when `snmp_send` set to `false` in `heapstats.conf`.

This issue is appeared trunk repos only.