### PR TITLE
Bug 3312: TConfiguration instance should be released at last

### DIFF
--- a/agent/src/heapstats-engines/libmain.cpp
+++ b/agent/src/heapstats-engines/libmain.cpp
@@ -654,9 +654,6 @@ JNIEXPORT void JNICALL Agent_OnUnload(JavaVM *vm) {
   /* Delete logger */
   delete logger;
 
-  /* Delete configuration */
-  delete conf;
-
   /* Free allocated configuration file path string. */
   free(loadConfigPath);
   loadConfigPath = NULL;
@@ -665,6 +662,9 @@ JNIEXPORT void JNICALL Agent_OnUnload(JavaVM *vm) {
   if (conf->SnmpSend()->get()) {
     TTrapSender::finalize();
   }
+
+  /* Delete configuration */
+  delete conf;
 }
 
 /*!


### PR DESCRIPTION
This PR is for [Bug 3312](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3312).

I found that `TConfiguration` instance `conf` is released before its read access in `Agent_OnUnload()`.

It should be released after all access.
This bug affects trunk repos only.