### PR TITLE
Bug 3322: TClassContainer instance might be broken in multithreaded access

### DIFF
--- a/agent/src/heapstats-engines/classContainer.hpp
+++ b/agent/src/heapstats-engines/classContainer.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file classContainer.hpp
  * \brief This file is used to add up using size every class.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -139,16 +139,6 @@ class TClassContainer {
     spinLockRelease(&lockval);
 
     return result;
-  }
-
-  /*!
-   * \brief Search class from container without container lock.
-   * \param klassOop [in] Target class oop.
-   * \return Class data of target class.
-   */
-  inline TObjectData *findClassWithoutLock(void *klassOop) {
-    TClassMap::iterator it = classMap->find(klassOop);
-    return (it != classMap->end()) ? it->second : NULL;
   }
 
   /*!

--- a/agent/src/heapstats-engines/snapShotMain.cpp
+++ b/agent/src/heapstats-engines/snapShotMain.cpp
@@ -335,7 +335,7 @@ inline TObjectData *getObjectDataFromKlassOop(TClassContainer *aClsContainer,
   TObjectData *clsData = NULL;
 
   /* Search child class at local class container. */
-  clsData = aClsContainer->findClassWithoutLock(klassOop);
+  clsData = aClsContainer->findClass(klassOop);
   if (unlikely(clsData == NULL)) {
     /* Search child class at root class container. */
     clsData = clsContainer->findClass(klassOop);


### PR DESCRIPTION
This PR is for [Bug 3322](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3322).

For performance reason, `TClassContainer` instance has hierarchical memory structure as below:

```
global contaner
 |- local container
 |- local container
 |- local container
     :
```

Each local containers are allocated in TLS - they will be had GC worker threads.
And `TClassContainer` provides lock-free find method which is named `findClassWithoutLock` because `TClassContainer` instance in own TLS should be accessed without lock.

However, it is insufficient.

If `ClassPrepare` / `ClassUnload` JVMTI events is fired by HotSpot, HeapStats agent will apply it to local container at first. Then it will apply all local container through global container.
`classMap` field in `TClassContainer` is `unordered_map`. If JVMTI events and `findClassWithoutLock` call at same time, `classMap` might be broken.

We should not use `findClassWithoutLock()`.