### PR TITLE
Bug 3323: Memory for thread name leaks in thread recorder

### DIFF
--- a/agent/src/heapstats-engines/threadRecorder.cpp
+++ b/agent/src/heapstats-engines/threadRecorder.cpp
@@ -1,7 +1,7 @@
 /*!
  * \iile threadRecorder.cpp
  * \brief Recording thread status.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -346,6 +346,19 @@ TThreadRecorder::TThreadRecorder(size_t buffer_size) : threadIDMap() {
  */
 TThreadRecorder::~TThreadRecorder() {
   munmap(record_buffer, aligned_buffer_size);
+
+  /* Deallocate memory for thread name. */
+  spinLockWait(&idmapLockVal);
+  {
+    for (std::tr1::unordered_map<jlong, char *,
+                                 TNumericalHasher<jlong> >::iterator itr =
+                                                            threadIDMap.begin();
+         itr != threadIDMap.end(); itr++) {
+      free(itr->second);
+    }
+  }
+  spinLockRelease(&idmapLockVal);
+
 }
 
 /*!


### PR DESCRIPTION
This PR is for [Bug 3323](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3323).

HeapStats calls `strdup()` for duplicating memory of thread name in thread recorder implementation. However, it remains after d'tor of `TThreadRecorder` call.

They should be free'ed in d'tor of `TThreadRecorder`.