### PR TITLE
Bug 3342: Replace LDDQU instruction for uncached memory regions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-03-25 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3342: Replace LDDQU instructions for uncached memory regions
+
 2017-02-27  Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 3331: Refactoring for memory management in HeapStats Agent

--- a/agent/src/heapstats-engines/arch/x86/avx/jvmInfo.inline.hpp
+++ b/agent/src/heapstats-engines/arch/x86/avx/jvmInfo.inline.hpp
@@ -35,10 +35,10 @@ inline void TJvmInfo::loadGCCause(void) {
    *     Code Name Sandy Bridge
    */
   asm volatile(
-    "vlddqu    (%0), %%ymm0;"
-    "vlddqu  32(%0), %%ymm1;"
+    "vmovdqu   (%0), %%ymm0;"
+    "vmovdqu 32(%0), %%ymm1;"
     "vmovdqa %%ymm0,   (%1);"
-    "vlddqu  64(%0), %%xmm0;"
+    "vmovdqu 64(%0), %%xmm0;"
     "vmovdqa %%ymm1, 32(%1);"
     "vmovdqa %%xmm0, 64(%1);"
     :

--- a/agent/src/heapstats-engines/arch/x86/sse3/jvmInfo.inline.hpp
+++ b/agent/src/heapstats-engines/arch/x86/sse3/jvmInfo.inline.hpp
@@ -35,13 +35,13 @@ inline void TJvmInfo::loadGCCause(void) {
    *     Code Name Sandy Bridge
    */
   asm volatile(
-    "lddqu    (%0), %%xmm0;"
-    "lddqu  16(%0), %%xmm1;"
+    "movdqu   (%0), %%xmm0;"
+    "movdqu 16(%0), %%xmm1;"
     "movdqa %%xmm0,   (%1);"
-    "lddqu  32(%0), %%xmm0;"
-    "lddqu  48(%0), %%xmm2;"
+    "movdqu 32(%0), %%xmm0;"
+    "movdqu 48(%0), %%xmm2;"
     "movdqa %%xmm1, 16(%1);"
-    "lddqu  64(%0), %%xmm1;"
+    "movdqu 64(%0), %%xmm1;"
     "movdqa %%xmm0, 32(%1);"
     "movdqa %%xmm2, 48(%1);"
     "movdqa %%xmm1, 64(%1);"


### PR DESCRIPTION
@YaSuenag suggested that we should not use LDDQU instructions for uncached memory regions according to intel's document([1]). That makes a sense, so we should replace LDDQU instructions to MOVDQU instructions.

[1] https://software.intel.com/en-us/blogs/2012/04/16/history-of-one-cpu-instructions-part-1-lddqumovdqu-explained
http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3342