### PR TITLE
Bug 3359: Ignore only auto generated Makefile

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -6,6 +6,8 @@ syntax: regexp
 #
 # Using negative lookahead expression
 ^(?!eclipse).*\.(settings|project|classpath)
+# Auto generated Makefile for mercurial
+^Makefile$
 
 syntax: glob
 target/*
@@ -31,8 +33,13 @@ analyzer/cli/heapstats-cli
 *.so.*
 *.lai
 *.class
-Makefile
 /heapstats.properties
+# Auto generated Makefile
+/Makefile
+mbean/**/Makefile
+agent/Makefile
+agent/src/**/Makefile
+agent/attacher/**/Makefile
 
 # SCM
 .hg


### PR DESCRIPTION
Now, we set SCM (git, mercurial) to ignore all Makefile. However, we need to manage Makefile which is not generated by configure automatically, e.g., agent/test/gtest/**/Makefile.

I confirmed that this patch ignore only auto generated Makefiles by below commands.

<details>
<summary>mercurial</summary>

```bash
/workspace/heapstats% find . -name "Makefile" | xargs hg debugignore
./mbean/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 39: 'mbean/**/Makefile')
./mbean/native/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 39: 'mbean/**/Makefile')
./agent/attacher/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 42: 'agent/attacher/**/Makefile')
./agent/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 40: 'agent/Makefile')
./agent/src/heapstats-engines/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 41: 'agent/src/**/Makefile')
./agent/src/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 41: 'agent/src/**/Makefile')
./agent/src/iotracer/Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 41: 'agent/src/**/Makefile')
./agent/test/gtest/Makefile is not ignored
./agent/test/gtest/src/stub/Makefile is not ignored
./agent/test/gtest/src/Makefile is not ignored
./Makefile is ignored
(ignore rule in /workspace/heapstats/.hgignore, line 10: '^Makefile$')
```
</details>

<details>
<summary>git</summary>

```bash
/workspace/heapstats% find . -name "Makefile" | xargs git check-ignore -v
.gitignore:39:mbean/**/Makefile ./mbean/Makefile
.gitignore:39:mbean/**/Makefile ./mbean/native/Makefile
.gitignore:42:agent/attacher/**/Makefile        ./agent/attacher/Makefile
.gitignore:40:agent/Makefile    ./agent/Makefile
.gitignore:41:agent/src/**/Makefile     ./agent/src/heapstats-engines/Makefile
.gitignore:41:agent/src/**/Makefile     ./agent/src/Makefile
.gitignore:41:agent/src/**/Makefile     ./agent/src/iotracer/Makefile
.gitignore:38:/Makefile ./Makefile
```
</details>

http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3359