### PR TITLE
Recommend jcmd instead of Attach API

### DIFF
--- a/agent/attacher/build.xml
+++ b/agent/attacher/build.xml
@@ -40,9 +40,6 @@
   <target name="jar" depends="compile">
     <jar destfile="${dist.dir}/heapstats-attacher.jar">
       <zipfileset dir="${build.dir}" excludes=".keep"/>
-      <manifest>
-        <attribute name="Main-Class" value="jp.co.ntt.oss.heapstats.attacher.AgentAttacher" />
-      </manifest>
     </jar>
   </target>
  

--- a/agent/attacher/build.xml
+++ b/agent/attacher/build.xml
@@ -40,6 +40,9 @@
   <target name="jar" depends="compile">
     <jar destfile="${dist.dir}/heapstats-attacher.jar">
       <zipfileset dir="${build.dir}" excludes=".keep"/>
+      <manifest>
+        <attribute name="Main-Class" value="jp.co.ntt.oss.heapstats.attacher.AgentAttacher" />
+      </manifest>
     </jar>
   </target>
  

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -165,9 +165,9 @@ bool TJvmInfo::setHSVersion(jvmtiEnv *jvmti) {
          * See https://bugs.openjdk.java.net/browse/JDK-8061493
          */
 #if USE_PCRE
-        TPCRERegex versionRegex("^(\\d+)-ea\\+(\\d+).*", 9);
+        TPCRERegex versionRegex("^(\\d+)-ea\\+(\\d+)$", 9);
 #else
-        TCPPRegex versionRegex("^(\\d+)-ea\\+(\\d+).*");
+        TCPPRegex versionRegex("^(\\d+)-ea\\+(\\d+)$");
 #endif
         if (versionRegex.find(versionStr)) {
           char *minorStr = versionRegex.group(1);

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -162,11 +162,12 @@ bool TJvmInfo::setHSVersion(jvmtiEnv *jvmti) {
       if (unlikely(result != 4)) {
         /*
          * Support JDK 9 EA
+         * See https://bugs.openjdk.java.net/browse/JDK-8061493
          */
 #if USE_PCRE
-        TPCRERegex versionRegex("^(\\d+)-ea\\+(\\d+)$", 9);
+        TPCRERegex versionRegex("^(\\d+)-ea\\+(\\d+).*", 9);
 #else
-        TCPPRegex versionRegex("^(\\d+)-ea\\+(\\d+)$");
+        TCPPRegex versionRegex("^(\\d+)-ea\\+(\\d+).*");
 #endif
         if (versionRegex.find(versionStr)) {
           char *minorStr = versionRegex.group(1);


### PR DESCRIPTION
OpenJDK community decided to disallow loading agents by default for [security and improving integrity for the modularity effort](https://bugs.openjdk.java.net/browse/JDK-8177154?focusedCommentId=14065964).

HeapStats provides an attacher by using this disallowed Attach API, so we should recommend jcmd instead if users use jdk9 or later.
