### PR TITLE
Bug 3382: Class Search window is too narrow

### DIFF
--- a/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
+++ b/analyzer/fx/src/main/resources/jp/co/ntt/oss/heapstats/plugin/builtin/snapshot/tabs/histogram.fxml
@@ -67,10 +67,10 @@
                 </VBox>
                 <VBox maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" spacing="5.0">
                     <children>
-                        <HBox spacing="5.0">
+                        <HBox maxWidth="1.7976931348623157E308" spacing="5.0">
                             <children>
                                 <Label text="%label.classsearch" />
-                                <TextField fx:id="searchText" onKeyReleased="#onSearchTextChanged" />
+                                <TextField fx:id="searchText" maxWidth="1.7976931348623157E308" minWidth="0.0" onKeyReleased="#onSearchTextChanged" HBox.hgrow="ALWAYS" />
                             </children>
                         </HBox>
                         <ListView fx:id="searchList" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="0.0" minWidth="0.0" VBox.vgrow="ALWAYS" />


### PR DESCRIPTION
This PR is for [Bug 3382](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3382).

Class Search text window in SnapShot Histogram tab is too narrow.
It should be fit the width of parent component (HBox).

* Current
![before](https://cloud.githubusercontent.com/assets/7421132/25982364/d6af3400-3716-11e7-9cfe-f47ea02d7219.png)

* After applying this change
![after](https://cloud.githubusercontent.com/assets/7421132/25982375/f058682c-3716-11e7-8961-2373a83c16e0.png)
