### PR TITLE
Bug 3399: Fix potential error when conflict between class loading and GC

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-06-08 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3399: Fix potential error when conflict between class loading and GC
+
 2017-05-12  Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 3382: Class Search window is too narrow

--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -906,8 +906,8 @@ int TClassContainer::afterTakeSnapShot(TSnapShotContainer *snapshot,
 void JNICALL
     OnClassUnload(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
   /*
-   * Class Unloading occurs at safepoint.
-   * So we need not to check whether this process called at normal execution.
+   * This function does not require to check whether at safepoint because
+   * Class Unloading always executes at safepoint.
    */
 
   /* Get klassOop. */

--- a/agent/src/heapstats-engines/classContainer.cpp
+++ b/agent/src/heapstats-engines/classContainer.cpp
@@ -905,6 +905,11 @@ int TClassContainer::afterTakeSnapShot(TSnapShotContainer *snapshot,
  */
 void JNICALL
     OnClassUnload(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
+  /*
+   * Class Unloading occurs at safepoint.
+   * So we need not to check whether this process called at normal execution.
+   */
+
   /* Get klassOop. */
   void *mirror = *(void **)klass;
   void *klassOop = TVMFunctions::getInstance()->AsKlassOop(mirror);

--- a/agent/src/heapstats-engines/deadlockFinder.cpp
+++ b/agent/src/heapstats-engines/deadlockFinder.cpp
@@ -62,16 +62,6 @@
 TDeadlockFinder *TDeadlockFinder::inst = NULL;
 
 
-/* Common methods. */
-
-/*!
- * \brief Get safepoint state.
- * \return Is synchronizing or working at safepoint now.
- */
-inline bool isAtSafepoint(void) {
-  return (TVMVariables::getInstance()->getSafePointState() == 2);
-}
-
 /*!
  * \brief Event handler of JVMTI MonitorContendedEnter for finding deadlock.
  * \param jvmti  [in] JVMTI environment.

--- a/agent/src/heapstats-engines/snapShotMain.cpp
+++ b/agent/src/heapstats-engines/snapShotMain.cpp
@@ -139,8 +139,8 @@ void JNICALL
     OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
 
   /*
-   * This process should be waited if VM is at safepoint (including safepoint
-   * synchronizing) because jclass (oop in JNIHandle) might be relocated.
+   * Wait if VM is at a safepoint which includes safepoint synchronizing,
+   * because jclass (oop in JNIHandle) might be relocated.
    */
   while (!isAtNormalExecution()) {
     sched_yield();

--- a/agent/src/heapstats-engines/vmVariables.hpp
+++ b/agent/src/heapstats-engines/vmVariables.hpp
@@ -37,7 +37,7 @@
 #define SAFEPOINT_STATE_SYMBOL "_ZN20SafepointSynchronize6_stateE"
 
 /*!
- * \brief Enumeration of safepoint state.
+ * \brief Numbering which shows safepoint state as enumeration.
  */
 #define SAFEPOINT_STATE_NORMAL_EXECUTION 0
 #define SAFEPOINT_STATE_SYNCHRONIZING    1

--- a/agent/src/heapstats-engines/vmVariables.hpp
+++ b/agent/src/heapstats-engines/vmVariables.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file vmVariables.hpp
  * \brief This file includes variables in HotSpot VM.
- * Copyright (C) 2014-2016 Yasumasa Suenaga
+ * Copyright (C) 2014-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,6 +36,12 @@
  */
 #define SAFEPOINT_STATE_SYMBOL "_ZN20SafepointSynchronize6_stateE"
 
+/*!
+ * \brief Enumeration of safepoint state.
+ */
+#define SAFEPOINT_STATE_NORMAL_EXECUTION 0
+#define SAFEPOINT_STATE_SYNCHRONIZING    1
+#define SAFEPOINT_STATE_SYNCHRONIZED     2
 
 /* extern variables */
 extern "C" void *collectedHeap;
@@ -465,6 +471,26 @@ class TVMVariables {
   inline void *getYoungGen() const { return youngGen; };
   inline void *getYoungGenStartAddr() const { return youngGenStartAddr; };
   inline size_t getYoungGenSize() const { return youngGenSize; };
+};
+
+/* Utility functions for Safepoint */
+
+/*!
+ * \brief Check whether VM is at safepoint or not.
+ * \return true if VM is at safepoint.
+ */
+inline bool isAtSafepoint(void) {
+  return (TVMVariables::getInstance()->getSafePointState()
+                                          == SAFEPOINT_STATE_SYNCHRONIZED);
+};
+
+/*!
+ * \brief Check whether VM is at normal execution or not.
+ * \return true if VM is at normal execution.
+ */
+inline bool isAtNormalExecution(void) {
+  return (TVMVariables::getInstance()->getSafePointState()
+                                          == SAFEPOINT_STATE_NORMAL_EXECUTION);
 };
 
 #endif  // VMVARIABLES_H


### PR DESCRIPTION
HeapStats will get an error at corner case when conflict between class loading and GC.
We should fix to prevent collected objects to not relocate more completely.

I will push this fix to all repositories which includes heapstats-1.x.

icedtea: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3399