### PR TITLE
Bug 3403: HeapStats Agent might crash if application exits with System.exit()

### DIFF
--- a/agent/src/heapstats-engines/heapstatsMBean.hpp
+++ b/agent/src/heapstats-engines/heapstatsMBean.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file heapstatsMBean.hpp
  * \brief JNI implementation for HeapStatsMBean.
- * Copyright (C) 2014 Yasumasa Suenaga
+ * Copyright (C) 2014-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -41,5 +41,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+void UnregisterHeapStatsNatives(JNIEnv *env);
 
 #endif  // HEAPSTATSMBEAN_HPP

--- a/agent/src/heapstats-engines/libmain.cpp
+++ b/agent/src/heapstats-engines/libmain.cpp
@@ -381,11 +381,6 @@ void JNICALL OnVMDeath(jvmtiEnv *jvmti, JNIEnv *env) {
     reloadSigMngr = NULL;
   }
 
-  /* Invoke JVM finalize event of snapshot function. */
-  onVMDeathForSnapShot(jvmti, env);
-  /* Invoke JVM finalize event of log function. */
-  onVMDeathForLog(jvmti, env);
-
   /* If agent is attaching now. */
   if (likely(conf->Attach()->get())) {
     /* Stop and disable each thread. */
@@ -396,6 +391,13 @@ void JNICALL OnVMDeath(jvmtiEnv *jvmti, JNIEnv *env) {
                                 conf->ThreadRecordFileName()->get());
     }
   }
+
+  /* Invoke JVM finalize event of snapshot function. */
+  onVMDeathForSnapShot(jvmti, env);
+  /* Invoke JVM finalize event of log function. */
+  onVMDeathForLog(jvmti, env);
+  /* Unregister native functions for HeapStats MBean */
+  UnregisterHeapStatsNatives(env);
 }
 
 /*!

--- a/agent/src/heapstats-engines/threadRecorder.cpp
+++ b/agent/src/heapstats-engines/threadRecorder.cpp
@@ -31,6 +31,13 @@
 #include <pthread.h>
 #include <sys/time.h>
 #include <sys/stat.h>
+#include <sched.h>
+
+#ifdef HAVE_ATOMIC
+#include <atomic>
+#else
+#include <cstdatomic>
+#endif
 
 #include "globals.hpp"
 #include "util.hpp"
@@ -51,6 +58,7 @@ TThreadRecorder *TThreadRecorder::inst = NULL;
 /* variables */
 jclass threadClass;
 jmethodID currentThreadMethod;
+static std::atomic_int processing(0);
 
 /* JVMTI event handler */
 
@@ -62,6 +70,7 @@ jmethodID currentThreadMethod;
  * \param thread [in] jthread object which is created.
  */
 void JNICALL OnThreadStart(jvmtiEnv *jvmti, JNIEnv *env, jthread thread) {
+  TProcessMark mark(processing);
   TThreadRecorder *recorder = TThreadRecorder::getInstance();
   recorder->registerNewThread(jvmti, thread);
   recorder->putEvent(thread, ThreadStart, 0);
@@ -75,6 +84,7 @@ void JNICALL OnThreadStart(jvmtiEnv *jvmti, JNIEnv *env, jthread thread) {
  * \param thread [in] jthread object which is created.
  */
 void JNICALL OnThreadEnd(jvmtiEnv *jvmti, JNIEnv *env, jthread thread) {
+  TProcessMark mark(processing);
   TThreadRecorder::getInstance()->putEvent(thread, ThreadEnd, 0);
 }
 
@@ -89,6 +99,7 @@ void JNICALL OnThreadEnd(jvmtiEnv *jvmti, JNIEnv *env, jthread thread) {
 void JNICALL
     OnMonitorContendedEnterForThreadRecording(jvmtiEnv *jvmti, JNIEnv *env,
                                               jthread thread, jobject object) {
+  TProcessMark mark(processing);
   TThreadRecorder::getInstance()->putEvent(thread, MonitorContendedEnter, 0);
 }
 
@@ -104,6 +115,7 @@ void JNICALL OnMonitorContendedEnteredForThreadRecording(jvmtiEnv *jvmti,
                                                          JNIEnv *env,
                                                          jthread thread,
                                                          jobject object) {
+  TProcessMark mark(processing);
   TThreadRecorder::getInstance()->putEvent(thread, MonitorContendedEntered, 0);
 }
 
@@ -118,6 +130,7 @@ void JNICALL OnMonitorContendedEnteredForThreadRecording(jvmtiEnv *jvmti,
  */
 void JNICALL OnMonitorWait(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread,
                            jobject object, jlong timeout) {
+  TProcessMark mark(processing);
   TThreadRecorder::getInstance()->putEvent(thread, MonitorWait, timeout);
 }
 
@@ -132,6 +145,7 @@ void JNICALL OnMonitorWait(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread,
  */
 void JNICALL OnMonitorWaited(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread,
                              jobject object, jboolean timeout) {
+  TProcessMark mark(processing);
   TThreadRecorder::getInstance()->putEvent(thread, MonitorWaited, timeout);
 }
 
@@ -141,6 +155,7 @@ void JNICALL OnMonitorWaited(jvmtiEnv *jvmti, JNIEnv *jni_env, jthread thread,
  * \param jvmti [in] JVMTI environment.
  */
 void JNICALL OnDataDumpRequestForDumpThreadRecordData(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
   TThreadRecorder::inst->dump(conf->ThreadRecordFileName()->get());
 }
 
@@ -168,6 +183,7 @@ void *GetCurrentThread(JNIEnv *env) {
  * \param millis [in] Time of sleeping.
  */
 void JNICALL JVM_SleepPrologue(JNIEnv *env, jclass threadClass, jlong millis) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            ThreadSleepStart, millis);
@@ -181,6 +197,7 @@ void JNICALL JVM_SleepPrologue(JNIEnv *env, jclass threadClass, jlong millis) {
  * \param millis [in] Time of sleeping.
  */
 void JNICALL JVM_SleepEpilogue(JNIEnv *env, jclass threadClass, jlong millis) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            ThreadSleepEnd, millis);
@@ -196,6 +213,7 @@ void JNICALL JVM_SleepEpilogue(JNIEnv *env, jclass threadClass, jlong millis) {
  */
 void JNICALL UnsafeParkPrologue(JNIEnv *env, jobject unsafe,
                                 jboolean isAbsolute, jlong time) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread, Park, time);
 }
@@ -210,17 +228,24 @@ void JNICALL UnsafeParkPrologue(JNIEnv *env, jobject unsafe,
  */
 void JNICALL UnsafeParkEpilogue(JNIEnv *env, jobject unsafe,
                                 jboolean isAbsolute, jlong time) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread, Unpark, time);
 }
 
 /* I/O tracer */
 
+/* Dummy method */
+void * JNICALL IoTrace_dummy(void) {
+  return NULL;
+}
+
 /*
  * Method:    socketReadBegin
  * Signature: ()Ljava/lang/Object;
  */
 JNIEXPORT jobject JNICALL IoTrace_socketReadBegin(JNIEnv *env, jclass cls) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            SocketReadStart, 0);
@@ -235,6 +260,7 @@ JNIEXPORT void JNICALL IoTrace_socketReadEnd(JNIEnv *env, jclass cls,
                                              jobject context, jobject address,
                                              jint port, jint timeout,
                                              jlong bytesRead) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            SocketReadEnd, bytesRead);
@@ -245,6 +271,7 @@ JNIEXPORT void JNICALL IoTrace_socketReadEnd(JNIEnv *env, jclass cls,
  * Signature: ()Ljava/lang/Object;
  */
 JNIEXPORT jobject JNICALL IoTrace_socketWriteBegin(JNIEnv *env, jclass cls) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            SocketWriteStart, 0);
@@ -258,6 +285,7 @@ JNIEXPORT jobject JNICALL IoTrace_socketWriteBegin(JNIEnv *env, jclass cls) {
 JNIEXPORT void JNICALL IoTrace_socketWriteEnd(JNIEnv *env, jclass cls,
                                               jobject context, jobject address,
                                               jint port, jlong bytesWritten) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            SocketWriteEnd, bytesWritten);
@@ -269,6 +297,7 @@ JNIEXPORT void JNICALL IoTrace_socketWriteEnd(JNIEnv *env, jclass cls,
  */
 JNIEXPORT jobject JNICALL
     IoTrace_fileReadBegin(JNIEnv *env, jclass cls, jstring path) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            FileReadStart, 0);
@@ -281,6 +310,7 @@ JNIEXPORT jobject JNICALL
  */
 JNIEXPORT void JNICALL IoTrace_fileReadEnd(JNIEnv *env, jclass cls,
                                            jobject context, jlong bytesRead) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            FileReadEnd, bytesRead);
@@ -292,6 +322,7 @@ JNIEXPORT void JNICALL IoTrace_fileReadEnd(JNIEnv *env, jclass cls,
  */
 JNIEXPORT jobject JNICALL
     IoTrace_fileWriteBegin(JNIEnv *env, jclass cls, jstring path) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            FileWriteStart, 0);
@@ -305,6 +336,7 @@ JNIEXPORT jobject JNICALL
 JNIEXPORT void JNICALL IoTrace_fileWriteEnd(JNIEnv *env, jclass cls,
                                             jobject context,
                                             jlong bytesWritten) {
+  TProcessMark mark(processing);
   void *javaThread = GetCurrentThread(env);
   TThreadRecorder::getInstance()->putEvent((jthread)&javaThread,
                                            FileWriteEnd, bytesWritten);
@@ -526,6 +558,55 @@ bool TThreadRecorder::registerIOTracer(jvmtiEnv *jvmti, JNIEnv *env) {
 }
 
 /*!
+ * \brief Unegister I/O tracer.
+ *
+ * \param env [in] JNI environment.
+ */
+void TThreadRecorder::UnregisterIOTracer(JNIEnv *env) {
+  if (conf->ThreadRecordIOTracer()->get() == NULL) {
+    return;
+  }
+
+  jclass iotraceClass = env->FindClass("sun/misc/IoTrace");
+
+  if (iotraceClass == NULL) {
+    env->ExceptionClear();  // It may occur NoClassDefFoumdError
+    return;
+  }
+
+  /* Register hook native methods. */
+  JNINativeMethod methods[] = {
+      {(char *)"socketReadBegin",
+       (char *)"()Ljava/lang/Object;",
+       (void *)&IoTrace_dummy},
+      {(char *)"socketReadEnd",
+       (char *)"(Ljava/lang/Object;Ljava/net/InetAddress;IIJ)V",
+       (void *)&IoTrace_dummy},
+      {(char *)"socketWriteBegin",
+       (char *)"()Ljava/lang/Object;",
+       (void *)&IoTrace_dummy},
+      {(char *)"socketWriteEnd",
+       (char *)"(Ljava/lang/Object;Ljava/net/InetAddress;IJ)V",
+       (void *)&IoTrace_dummy},
+      {(char *)"fileReadBegin",
+       (char *)"(Ljava/lang/String;)Ljava/lang/Object;",
+       (void *)&IoTrace_dummy},
+      {(char *)"fileReadEnd",
+       (char *)"(Ljava/lang/Object;J)V",
+       (void *)&IoTrace_dummy},
+      {(char *)"fileWriteBegin",
+       (char *)"(Ljava/lang/String;)Ljava/lang/Object;",
+       (void *)&IoTrace_dummy},
+      {(char *)"fileWriteEnd",
+       (char *)"(Ljava/lang/Object;J)V",
+       (void *)&IoTrace_dummy}};
+
+  env->RegisterNatives(iotraceClass, methods, 8);
+
+  return;
+}
+
+/*!
  * \brief Initialize HeapStats Thread Recorder.
  *
  * \param jvmti [in] JVMTI environment.
@@ -625,6 +706,14 @@ void TThreadRecorder::finalize(jvmtiEnv *jvmti, JNIEnv *env,
   /* Stop to hook JNI function */
   TJVMSleepCallback::switchCallback(env, false);
   TUnsafeParkCallback::switchCallback(env, false);
+
+  /* Stop to hook IoTrace */
+  UnregisterIOTracer(env);
+
+  /* Wait until all tasks are finished. */
+  while (processing > 0) {
+    sched_yield();
+  }
 
   /* Stop HeapStats Thread Recorder */
   inst->dump(fname);

--- a/agent/src/heapstats-engines/threadRecorder.hpp
+++ b/agent/src/heapstats-engines/threadRecorder.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file threadRecorder.hpp
  * \brief Recording thread status.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -176,6 +176,13 @@ class TThreadRecorder {
    * \return true if succeeded.
    */
   static bool registerIOTracer(jvmtiEnv *jvmti, JNIEnv *env);
+
+  /*!
+   * \brief Unegister I/O tracer.
+   *
+   * \param env [in] JNI environment.
+   */
+  static void UnregisterIOTracer(JNIEnv *env);
 
  public:
   /*!

--- a/agent/src/heapstats-engines/util.hpp
+++ b/agent/src/heapstats-engines/util.hpp
@@ -25,6 +25,12 @@
 #include <jvmti.h>
 #include <jni.h>
 
+#ifdef HAVE_ATOMIC
+#include <atomic>
+#else
+#include <cstdatomic>
+#endif
+
 #include <stddef.h>
 #include <errno.h>
 #include <string.h>
@@ -365,6 +371,20 @@ class TNumericalHasher {
    * \return Hash value.
    */
   size_t operator()(const T &val) const { return (size_t)val; };
+};
+
+/*!
+ * \brief Utility class for flag of processing.
+ */
+class TProcessMark {
+
+  private:
+    std::atomic_int &flag;
+
+  public:
+    TProcessMark(std::atomic_int &flg) : flag(flg) { flag++; }
+    ~TProcessMark() { flag--; }
+
 };
 
 /* CPU Specific utilities. */

--- a/configure
+++ b/configure
@@ -6471,6 +6471,38 @@ else
   USE_PCRE_FALSE=
 fi
 
+
+# Check for atomic operation
+for ac_header in atomic
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "atomic" "ac_cv_header_atomic" "$ac_includes_default"
+if test "x$ac_cv_header_atomic" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_ATOMIC 1
+_ACEOF
+
+else
+
+  for ac_header in cstdatomic
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "cstdatomic" "ac_cv_header_cstdatomic" "$ac_includes_default"
+if test "x$ac_cv_header_cstdatomic" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_CSTDATOMIC 1
+_ACEOF
+
+else
+  as_fn_error $? "Compiler does not support C++ atomic." "$LINENO" 5
+fi
+
+done
+
+
+fi
+
+done
+
+
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'

--- a/configure.ac
+++ b/configure.ac
@@ -99,6 +99,14 @@ AC_RUN_IFELSE(
   ]
 )
 AM_CONDITIONAL(USE_PCRE, test -n "${ac_cv_header_pcre_h}")
+
+# Check for atomic operation
+AC_CHECK_HEADERS([atomic], [],
+[
+  AC_CHECK_HEADERS([cstdatomic], [],
+                        [AC_MSG_ERROR([Compiler does not support C++ atomic.])])
+])
+
 AC_LANG_POP([C++])
 
 # Checks for library header files.


### PR DESCRIPTION
This PR is for [Bug 3403](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3403).

I confirmed crash if application exits with `System.exit()` and `ResourceExhausted` JVMTI callback is working.

According to HotSpot implementation, `System.exit()` calls `JVM_Halt()`. This function will stop the process without checking status (working) all Java threads. Thus shutdown process might be started in spite of JVMTI and JNI functions are working.

We should avoid this case.

I want to use `atomic_int` in C++11 for processing flag.
We decided to remove RHEL 5 support in trunk (2.1) repo. So we use new C++ compiler which supports C++11 atomic.
So I target this fix to trunk only.

http://icedtea.classpath.org/pipermail/heapstats/2017-June/002105.html