### PR TITLE
Bug 3405: HeapStats Agent cannot be built on CentOS 6 after Bug 3403

### DIFF
--- a/configure
+++ b/configure
@@ -6349,10 +6349,7 @@ $as_echo "$as_me: not updating unwritable cache $cache_file" >&6;}
 fi
 rm -f confcache
 
-# Check C++11 regex
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for std::regex" >&5
-$as_echo_n "checking for std::regex... " >&6; }
-
+# Check C++11 support
 ac_ext=cpp
 ac_cpp='$CXXCPP $CPPFLAGS'
 ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -6361,7 +6358,40 @@ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
 
 ORIG_CXXFLAGS=$CXXFLAGS
 CXXFLAGS+=" -std=c++11"
+CPP11=1
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking C++11 support" >&5
+$as_echo_n "checking C++11 support... " >&6; }
+
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_compile "$LINENO"; then :
+
+else
+   CPP11=0
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+if test $CPP11 -eq 1; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: c++11" >&5
+$as_echo "c++11" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: c++0x" >&5
+$as_echo "c++0x" >&6; }
+  CXXFLAGS="$ORIG_CXXFLAGS -std=c++0x"
+fi
+
+# Check C++11 regex
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for std::regex" >&5
+$as_echo_n "checking for std::regex... " >&6; }
 
 
 if test "$cross_compiling" = yes; then :
@@ -6400,7 +6430,6 @@ else
 $as_echo "no" >&6; }
     $as_echo "#define USE_PCRE 1" >>confdefs.h
 
-    CXXFLAGS=$ORIG_CXXFLAGS
     for ac_header in pcre.h
 do :
   ac_fn_cxx_check_header_mongrel "$LINENO" "pcre.h" "ac_cv_header_pcre_h" "$ac_includes_default"
@@ -6483,7 +6512,6 @@ _ACEOF
 
 else
 
-  CXXFLAGS+=" -std=c++0x"
   for ac_header in cstdatomic
 do :
   ac_fn_cxx_check_header_mongrel "$LINENO" "cstdatomic" "ac_cv_header_cstdatomic" "$ac_includes_default"

--- a/configure
+++ b/configure
@@ -6483,6 +6483,7 @@ _ACEOF
 
 else
 
+  CXXFLAGS+=" -std=c++0x"
   for ac_header in cstdatomic
 do :
   ac_fn_cxx_check_header_mongrel "$LINENO" "cstdatomic" "ac_cv_header_cstdatomic" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -72,12 +72,23 @@ AC_CHECK_HEADERS([ \
 AC_CHECK_HEADERS([sys/auxv.h], [], [])  # Supplemental headers
 AC_CACHE_SAVE
 
-# Check C++11 regex
-AC_MSG_CHECKING([for std::regex])
-
+# Check C++11 support
 AC_LANG_PUSH([C++])
 ORIG_CXXFLAGS=$CXXFLAGS
 CXXFLAGS+=" -std=c++11"
+CPP11=1
+
+AC_MSG_CHECKING([C++11 support])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([])], [], [ CPP11=0 ])
+if test $CPP11 -eq 1; then
+  AC_MSG_RESULT([c++11])
+else
+  AC_MSG_RESULT([c++0x])
+  CXXFLAGS="$ORIG_CXXFLAGS -std=c++0x"
+fi
+
+# Check C++11 regex
+AC_MSG_CHECKING([for std::regex])
 
 AC_RUN_IFELSE(
   [AC_LANG_PROGRAM(
@@ -93,7 +104,6 @@ AC_RUN_IFELSE(
   ], [
     AC_MSG_RESULT([no])
     AC_DEFINE(USE_PCRE,1)
-    CXXFLAGS=$ORIG_CXXFLAGS
     AC_CHECK_HEADERS([pcre.h], [], [AC_MSG_ERROR([PCRE not found.])])
     AC_CHECK_LIB([pcre], [main], [], [AC_MSG_ERROR([PCRE not found.])])
   ]
@@ -103,7 +113,6 @@ AM_CONDITIONAL(USE_PCRE, test -n "${ac_cv_header_pcre_h}")
 # Check for atomic operation
 AC_CHECK_HEADERS([atomic], [],
 [
-  CXXFLAGS+=" -std=c++0x"
   AC_CHECK_HEADERS([cstdatomic], [],
                         [AC_MSG_ERROR([Compiler does not support C++ atomic.])])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -103,6 +103,7 @@ AM_CONDITIONAL(USE_PCRE, test -n "${ac_cv_header_pcre_h}")
 # Check for atomic operation
 AC_CHECK_HEADERS([atomic], [],
 [
+  CXXFLAGS+=" -std=c++0x"
   AC_CHECK_HEADERS([cstdatomic], [],
                         [AC_MSG_ERROR([Compiler does not support C++ atomic.])])
 ])


### PR DESCRIPTION
This PR is for [Bug 3405](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3405).

In Bug 3403, I use C++ atomic class to represent processing in HeapStats agent.
GCC 4.4.7 in CentOS 6.5 requires `-std=c++0x` compiler option to use it, however I've not added it.

We should added `-std=c++0x` to `CXXFLAGS` to compile with GCC 4.4.7 .

This issue appears on older C++ compiler only.
On GCC 6.3.1 on Fedora 25 (and C++11 supported compiler), it supports `-std=c++11` and it will added in C++ regex checking. This change does not affect these modern compilers because `configure.ac` will add `-std=c++11` automatically.