### PR TITLE
Bug 3406: [TEST]Add race condition tests for core components

### DIFF
--- a/agent/src/heapstats-engines/gcWatcher.cpp
+++ b/agent/src/heapstats-engines/gcWatcher.cpp
@@ -73,6 +73,7 @@ void JNICALL TGCWatcher::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
         pthread_cond_wait(&controller->mutexCond, &controller->mutex);
       }
 
+RACE_COND_DEBUG_POINT:
       /* If waiting finished by notification. */
       if (likely(controller->_numRequests > 0)) {
         controller->_numRequests--;

--- a/agent/src/heapstats-engines/snapShotProcessor.cpp
+++ b/agent/src/heapstats-engines/snapShotProcessor.cpp
@@ -80,6 +80,7 @@ void JNICALL
         pthread_cond_wait(&controller->mutexCond, &controller->mutex);
       }
 
+RACE_COND_DEBUG_POINT:
       /* If get notification means output. */
       if (likely(controller->_numRequests > 0)) {
         controller->_numRequests--;

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare/test.py
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ClassPrepare/buildenv.sh

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "OnClassPrepare", Cond_OnClassPrepare, False, False, True)

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/testcase
+++ b/agent/test/race-condition/ClassPrepare/ClassPrepare_safepoint/testcase
@@ -1,0 +1,1 @@
+../ClassPrepare/testcase

--- a/agent/test/race-condition/ClassPrepare/DataDumpRequest/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/DataDumpRequest/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH="$JAVA_HOME/lib/tools.jar:testcase"

--- a/agent/test/race-condition/ClassPrepare/DataDumpRequest/test.py
+++ b/agent/test/race-condition/ClassPrepare/DataDumpRequest/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/DataDumpRequest/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/DataDumpRequest/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.stream.*;
 import java.net.*;
 import java.nio.file.*;

--- a/agent/test/race-condition/ClassPrepare/DataDumpRequest/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/DataDumpRequest/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/test.py
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/test.py
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True)

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/Test.java
@@ -1,0 +1,22 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+
+    ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+
+    Class<?> target = loader.loadClass("DynLoad");
+    Method targetMethod = target.getMethod("call");
+    Object targetObj = target.newInstance();
+    targetMethod.invoke(targetObj);
+  }
+
+}

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../GCWatcher/buildenv.sh

--- a/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True, False, True)

--- a/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/testcase
+++ b/agent/test/race-condition/ClassPrepare/GCWatcher_safepoint/testcase
@@ -1,0 +1,1 @@
+../GCWatcher/testcase

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted/test.py
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../MemoryExhausted/buildenv.sh

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "OnResourceExhausted", common.return_true, True, False, True)

--- a/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/testcase
+++ b/agent/test/race-condition/ClassPrepare/MemoryExhausted_safepoint/testcase
@@ -1,0 +1,1 @@
+../MemoryExhausted/testcase

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/test.py
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEnter/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/test.py
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorContendedEntered/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/MonitorWait/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MonitorWait/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/MonitorWait/test.py
+++ b/agent/test/race-condition/ClassPrepare/MonitorWait/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MonitorWait/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorWait/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/MonitorWait/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorWait/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/MonitorWaited/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/MonitorWaited/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/MonitorWaited/test.py
+++ b/agent/test/race-condition/ClassPrepare/MonitorWaited/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/MonitorWaited/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorWaited/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/MonitorWaited/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/MonitorWaited/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True)

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/Test.java
@@ -1,0 +1,22 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+
+    ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+
+    Class<?> target = loader.loadClass("DynLoad");
+    Method targetMethod = target.getMethod("call");
+    Object targetObj = target.newInstance();
+    targetMethod.invoke(targetObj);
+  }
+
+}

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../SnapShotProcessor/buildenv.sh

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True, False, True)

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/testcase
+++ b/agent/test/race-condition/ClassPrepare/SnapShotProcessor_safepoint/testcase
@@ -1,0 +1,1 @@
+../SnapShotProcessor/testcase

--- a/agent/test/race-condition/ClassPrepare/ThreadEnd/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ThreadEnd/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/ThreadEnd/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadEnd/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ThreadEnd/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadEnd/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/ThreadEnd/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadEnd/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ThreadExhausted/buildenv.sh

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "OnResourceExhausted", common.return_true, True, False, True)

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,68 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void consumeMemory(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(1000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void runClassLoad(){
+    try{
+      ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+      Class<?> target = loader.loadClass("DynLoad");
+      Method targetMethod = target.getMethod("call");
+      Object targetObj = target.newInstance();
+      targetMethod.invoke(targetObj);
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runClassLoad)).start();
+    (new Thread(Test::runThreadleak)).start();
+
+    /* Avoid PythonException not to create native thread for executing jcmd */
+    Thread th = new Thread(Test::consumeMemory);
+    th.setDaemon(true);
+    th.start();
+  }
+}

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/ClassPrepare/ThreadStart/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/ThreadStart/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/ThreadStart/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/ThreadStart/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadStart/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/ThreadStart/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/ThreadStart/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ClassPrepare/VMDeath/buildenv.sh
+++ b/agent/test/race-condition/ClassPrepare/VMDeath/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ClassPrepare/VMDeath/test.py
+++ b/agent/test/race-condition/ClassPrepare/VMDeath/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ClassPrepare/VMDeath/testcase/Test.java
+++ b/agent/test/race-condition/ClassPrepare/VMDeath/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ClassPrepare/VMDeath/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ClassPrepare/VMDeath/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/GCWatcher/CMSRemark/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/CMSRemark/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/CMSRemark/test.py
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/CMSRemark/test.py
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "VM_CMS_Final_Remark::doit", common.return_true, False)

--- a/agent/test/race-condition/GCWatcher/CMSRemark/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/CMSRemark/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/CMSRemark/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/test.py
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/test.py
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "callbackForG1Cleanup", common.return_true, False)

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/G1Cleanup/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/G1Cleanup/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/test.py
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/test.py
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, True)

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.*;
 
 

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted/testcase/Test.java
@@ -1,0 +1,32 @@
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runGC(){
+    try{
+      while(true){
+        System.gc();
+        Thread.sleep(100);
+      }
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  public static void main(String[] args){
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+    gcThread.start();
+    (new Thread(Test::runMemleak)).start();
+  }
+}

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../MemoryExhausted/buildenv.sh

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time, threading
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time, threading
+sys.path.append(os.pardir + "/../")
+
+import common
+
+# Kick GC after occurring GC.
+def Kick_GC():
+    threading.Thread(target=os.system, args=("jcmd 0 GC.run",)).start()
+    return True
+
+
+common.initialize("OnResourceExhausted", Kick_GC, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,18 @@
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/MemoryExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.*;
 
 

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/test.py
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/test.py
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True)

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/Test.java
@@ -1,0 +1,22 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+
+    ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+
+    Class<?> target = loader.loadClass("DynLoad");
+    Method targetMethod = target.getMethod("call");
+    Object targetObj = target.newInstance();
+    targetMethod.invoke(targetObj);
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../OnClassPrepare/buildenv.sh

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, False, True)

--- a/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/testcase
+++ b/agent/test/race-condition/GCWatcher/OnClassPrepare_safepoint/testcase
@@ -1,0 +1,1 @@
+../OnClassPrepare/testcase/

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmn10m -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "VM_GenCollectForAllocation::doit", common.return_true, False)

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.*;
 
 public class Test{

--- a/agent/test/race-condition/GCWatcher/ParNewGCStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParNewGCStart/testcase/Test.java
@@ -1,0 +1,17 @@
+import java.util.*;
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+
+    List<byte[]> list = new ArrayList<>();
+    for(int i = 1; i < 10; i++){
+      list.add(new byte[1024 * 1024]); // 1MB
+    }
+
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseParallelGC -XX:-UseParallelOldGC"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnGarbageCollectionStart", common.return_true, False)

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParallelGarbageCollectionStart/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:-UseParallelOldGC"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnGarbageCollectionStart", common.return_true, False)

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ParallelOldGarbageCollectionStart/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, True)

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
@@ -1,0 +1,8 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../SnapShotProcessor/buildenv.sh

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, True, True)

--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/testcase
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor_safepoint/testcase
@@ -1,0 +1,1 @@
+../SnapShotProcessor/testcase

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/buildenv.sh
@@ -1,3 +1,21 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/test.py
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/test.py
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, True)

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void runThreadleak(){

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted/testcase/Test.java
@@ -1,0 +1,30 @@
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    System.gc();
+  }
+}

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ThreadExhausted/buildenv.sh

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True, True, True)

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void runThreadleak(){

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,42 @@
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(10000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    (new Thread(Test::runGC)).start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True)

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/Test.java
@@ -1,0 +1,37 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runClassLoad(){
+    try{
+      ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+      Class<?> target = loader.loadClass("DynLoad");
+      Method targetMethod = target.getMethod("call");
+      Object targetObj = target.newInstance();
+      targetMethod.invoke(targetObj);
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runClassLoad)).start();
+    (new Thread(Test::runMemleak)).start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/dynload/DynLoad.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ClassPrepare/buildenv.sh

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, False, True)

--- a/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/testcase
+++ b/agent/test/race-condition/MemoryExhausted/ClassPrepare_safepoint/testcase
@@ -1,0 +1,1 @@
+../ClassPrepare/testcase/

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/test.py
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False)

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/test.py
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/testcase/Test.java
@@ -1,0 +1,38 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      try{
+        System.gc();
+        Thread.sleep(100);
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    Thread memleakThread = new Thread(Test::runMemleak);
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+
+    gcThread.start();
+    memleakThread.start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../GCWatcher/buildenv.sh

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time, threading
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/test.py
@@ -1,0 +1,11 @@
+import sys, os, time, threading
+sys.path.append(os.pardir + "/../")
+
+import common
+
+# Kick GC after occurring GC.
+def Kick_GC():
+    threading.Thread(target=os.system, args=("jcmd 0 GC.run",)).start()
+    return True
+
+common.initialize("OnResourceExhausted", Kick_GC, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/GCWatcher_safepoint/testcase/Test.java
@@ -1,0 +1,20 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/test.py
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/test.py
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False)

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/testcase/Test.java
@@ -1,0 +1,21 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+    (new Thread(Test::runMemleak)).start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../MemoryExhausted/buildenv.sh

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)

--- a/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/testcase
+++ b/agent/test/race-condition/MemoryExhausted/MemoryExhausted_safepoint/testcase
@@ -1,0 +1,1 @@
+../MemoryExhausted/testcase

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False)

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/testcase/Test.java
@@ -1,0 +1,38 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      try{
+        System.gc();
+        Thread.sleep(100);
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    Thread memleakThread = new Thread(Test::runMemleak);
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+
+    gcThread.start();
+    memleakThread.start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../SnapShotProcessor/buildenv.sh

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/testcase
+++ b/agent/test/race-condition/MemoryExhausted/SnapShotProcessor_safepoint/testcase
@@ -1,0 +1,1 @@
+../SnapShotProcessor/testcase

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/test.py
@@ -1,0 +1,21 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+import re
+
+# from jvmti.h
+JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP = 0x0002
+JVMTI_RESOURCE_EXHAUSTED_THREADS = 0x0004
+
+def flagToInt():
+    m = re.search("\d+$", gdb.execute("p flags", False, True))
+    return int(m.group(0))
+
+def Cond_MemoryExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP) != 0)
+
+def Cond_ThreadExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
+
+common.initialize("OnResourceExhausted", Cond_MemoryExhausted, "OnResourceExhausted", Cond_ThreadExhausted, True)

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted/testcase/Test.java
@@ -1,0 +1,44 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+  }
+}

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ThreadExhausted/buildenv.sh

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
@@ -1,0 +1,21 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+import re
+
+# from jvmti.h
+JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP = 0x0002
+JVMTI_RESOURCE_EXHAUSTED_THREADS = 0x0004
+
+def flagToInt():
+    m = re.search("\d+$", gdb.execute("p flags", False, True))
+    return int(m.group(0))
+
+def Cond_MemoryExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP) != 0)
+
+def Cond_ThreadExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
+
+common.initialize("OnResourceExhausted", Cond_MemoryExhausted, "OnResourceExhausted", Cond_ThreadExhausted, True, False, True)

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,57 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(1000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runGC)).start();
+    (new Thread(Test::runMemleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+  }
+}

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "VM_CMS_Final_Remark::doit", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/testcase/Test.java
@@ -1,0 +1,11 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+    Thread.sleep(10000); // Sleep 10 secs again to avoid missing...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/CMSRemark/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/CMSRemark/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseG1GC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "callbackForG1Cleanup", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/G1Cleanup/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/G1Cleanup/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
@@ -1,0 +1,8 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../GCWatcher/buildenv.sh

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/testcase
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher_safepoint/testcase
@@ -1,0 +1,1 @@
+../GCWatcher/testcase

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/testcase/Test.java
@@ -1,0 +1,17 @@
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+  }
+}

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.*;
 
 

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../MemoryExhausted/buildenv.sh

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)

--- a/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/testcase
+++ b/agent/test/race-condition/SnapShotProcessor/MemoryExhausted_safepoint/testcase
@@ -1,0 +1,1 @@
+../MemoryExhausted/testcase/

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True)

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/Test.java
@@ -1,0 +1,22 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+
+    ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+
+    Class<?> target = loader.loadClass("DynLoad");
+    Method targetMethod = target.getMethod("call");
+    Object targetObj = target.newInstance();
+    targetMethod.invoke(targetObj);
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../OnClassPrepare/buildenv.sh

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, False, True)

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/testcase
+++ b/agent/test/race-condition/SnapShotProcessor/OnClassPrepare_safepoint/testcase
@@ -1,0 +1,1 @@
+../OnClassPrepare/testcase

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmn10m -XX:+UseConcMarkSweepGC -XX:+ExplicitGCInvokesConcurrent"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "VM_GenCollectForAllocation::doit", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.util.*;
 
 public class Test{

--- a/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParNewGCStart/testcase/Test.java
@@ -1,0 +1,17 @@
+import java.util.*;
+
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+
+    List<byte[]> list = new ArrayList<>();
+    for(int i = 1; i < 10; i++){
+      list.add(new byte[1024 * 1024]); // 1MB
+    }
+
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:+UseParallelGC -XX:-UseParallelOldGC"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnGarbageCollectionStart", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelGarbageCollectionStart/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/buildenv.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-XX:-UseParallelOldGC"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnGarbageCollectionStart", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/testcase/Test.java
@@ -1,0 +1,9 @@
+public class Test{
+
+  public static void main(String[] args) throws Exception{
+    System.gc();
+    Thread.sleep(3000); // Sleep 3 secs to wait breakpoint...
+    System.gc();
+  }
+
+}

--- a/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ParallelOldGarbageCollectionStart/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void main(String[] args) throws Exception{

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False)

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void runThreadleak(){

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted/testcase/Test.java
@@ -1,0 +1,30 @@
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    System.gc();
+  }
+}

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ThreadExhausted/buildenv.sh

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void runThreadleak(){

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,42 @@
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(10000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    (new Thread(Test::runGC)).start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/test.py
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False)

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/test.py
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher/testcase/Test.java
@@ -1,0 +1,53 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      try{
+        System.gc();
+        Thread.sleep(100);
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    Thread threadleakThread = new Thread(Test::runThreadleak);
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+
+    gcThread.start();
+    threadleakThread.start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../GCWatcher/buildenv.sh

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
@@ -1,0 +1,7 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class Test{
 
   public static void runThreadleak(){

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/testcase/Test.java
@@ -1,0 +1,42 @@
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(10000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    (new Thread(Test::runGC)).start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/test.py
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/test.py
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/test.py
@@ -1,0 +1,21 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+import re
+
+# from jvmti.h
+JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP = 0x0002
+JVMTI_RESOURCE_EXHAUSTED_THREADS = 0x0004
+
+def flagToInt():
+    m = re.search("\d+$", gdb.execute("p flags", False, True))
+    return int(m.group(0))
+
+def Cond_MemoryExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP) != 0)
+
+def Cond_ThreadExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
+
+common.initialize("OnResourceExhausted", Cond_ThreadExhausted, "OnResourceExhausted", Cond_MemoryExhausted, True)

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted/testcase/Test.java
@@ -1,0 +1,44 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../MemoryExhausted/buildenv.sh

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
@@ -1,0 +1,21 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+import re
+
+# from jvmti.h
+JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP = 0x0002
+JVMTI_RESOURCE_EXHAUSTED_THREADS = 0x0004
+
+def flagToInt():
+    m = re.search("\d+$", gdb.execute("p flags", False, True))
+    return int(m.group(0))
+
+def Cond_MemoryExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_JAVA_HEAP) != 0)
+
+def Cond_ThreadExhausted():
+  return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
+
+common.initialize("OnResourceExhausted", Cond_ThreadExhausted, "OnResourceExhausted", Cond_MemoryExhausted, True, False, True)

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,60 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runMemleak(){
+    List<byte[]> list = new ArrayList<>();
+
+    while(true){
+      list.add(new byte[1024*1024]);
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(1000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runMemleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+    gcThread.start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/buildenv.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+unset JAVA_OPTS
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/dynload/DynLoad.java
+
+ulimit -Su 500
+

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/test.py
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/test.py
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True)

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/Test.java
@@ -1,0 +1,51 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void runClassLoad(){
+    try{
+      ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+      Class<?> target = loader.loadClass("DynLoad");
+      Method targetMethod = target.getMethod("call");
+      Object targetObj = target.newInstance();
+      targetMethod.invoke(targetObj);
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runClassLoad)).start();
+    (new Thread(Test::runThreadleak)).start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../OnClassPrepare/buildenv.sh

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
@@ -1,0 +1,12 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+def Cond_OnClassPrepare():
+    gdb.newest_frame().older().select()
+    symbol = gdb.execute("p (char *)klass->_name->_body", False, True)
+    return (symbol.find("DynLoad") != -1)
+
+
+common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, False, True)

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/Test.java
@@ -1,0 +1,67 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+
+
+public class Test{
+
+  public static void runClassLoad(){
+    try{
+      ClassLoader loader = new URLClassLoader(new URL[]{
+                     Paths.get(System.getProperty("java.class.path"), "dynload")
+                          .toUri()
+                          .toURL()});
+      Class<?> target = loader.loadClass("DynLoad");
+      Method targetMethod = target.getMethod("call");
+      Object targetObj = target.newInstance();
+      targetMethod.invoke(targetObj);
+    }
+    catch(Exception e){
+      e.printStackTrace();
+    }
+  }
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(1000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runClassLoad)).start();
+    (new Thread(Test::runThreadleak)).start();
+
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+    gcThread.start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/dynload/DynLoad.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 public class DynLoad{
   public void call(){
     System.out.println("from " + Thread.currentThread().getName());

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/dynload/DynLoad.java
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/testcase/dynload/DynLoad.java
@@ -1,0 +1,5 @@
+public class DynLoad{
+  public void call(){
+    System.out.println("from " + Thread.currentThread().getName());
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/test.py
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False)

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor/testcase/Test.java
@@ -1,0 +1,53 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      try{
+        System.gc();
+        Thread.sleep(100);
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    Thread threadleakThread = new Thread(Test::runThreadleak);
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+
+    gcThread.start();
+    threadleakThread.start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../SnapShotProcessor/buildenv.sh

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/testcase
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/testcase
@@ -1,0 +1,1 @@
+../SnapShotProcessor/testcase

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/buildenv.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 export CLASSPATH=testcase

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/buildenv.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export CLASSPATH=testcase
+export MAINCLASS=Test
+export JAVA_OPTS="-Xmx500m"
+unset HEAPSTATS_CONF
+
+$JAVA_HOME/bin/javac $TEST_TARGET/testcase/Test.java
+
+ulimit -Su 500

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/test.py
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/test.py
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False)

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/testcase/Test.java
@@ -1,0 +1,36 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+  }
+}

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/buildenv.sh
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/buildenv.sh
@@ -1,0 +1,1 @@
+../ThreadExhausted/buildenv.sh

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import sys, os, time
 sys.path.append(os.pardir + "/../")
 

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
@@ -1,0 +1,6 @@
+import sys, os, time
+sys.path.append(os.pardir + "/../")
+
+import common
+
+common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,3 +1,39 @@
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+/*
+ * Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
 import java.net.*;
 import java.nio.file.*;
 import java.lang.reflect.*;

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/testcase/Test.java
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/testcase/Test.java
@@ -1,0 +1,52 @@
+import java.net.*;
+import java.nio.file.*;
+import java.lang.reflect.*;
+import java.util.*;
+
+
+public class Test{
+
+  public static void runThreadleak(){
+    Runnable waiter = () -> {
+      try{
+        synchronized(Test.class){
+          Test.class.wait();
+        }
+      }
+      catch(InterruptedException e){
+        e.printStackTrace();
+      }
+    };
+
+    while(true){
+      try{
+        (new Thread(waiter)).start();
+      }
+      catch(Throwable t){
+        t.printStackTrace();
+        System.exit(-1);
+      }
+    }
+  }
+
+  public static void runGC(){
+    while(true){
+      System.gc();
+      try{
+        Thread.sleep(1000);
+      }
+      catch(Exception e){
+        e.printStackTrace();
+      }
+    }
+  }
+
+  public static void main(String[] args){
+    (new Thread(Test::runThreadleak)).start();
+    (new Thread(Test::runThreadleak)).start();
+
+    Thread gcThread = new Thread(Test::runGC);
+    gcThread.setDaemon(true);
+    gcThread.start();
+  }
+}

--- a/agent/test/race-condition/common.py
+++ b/agent/test/race-condition/common.py
@@ -1,3 +1,21 @@
+'''
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+'''
+
 import gdb, threading, os
 
 class ContinueInvoker:

--- a/agent/test/race-condition/testcase.sh
+++ b/agent/test/race-condition/testcase.sh
@@ -3,7 +3,7 @@
 pushd $(dirname $0) >/dev/null
 
 if [[ $1 == "--clean" ]]; then
-  find . \( -name "*.class" -o -name "core*" -o -name "hs_err*log" -o -name "*.gdb" -o -name "*.log" -o -name command.gdb -o -name "heapstats_*" -o -name "test-failed" -o -name "test-succeeded" \) -exec rm -f {} \;
+  find . \( -name "*.class" -o -name "core*" -o -name "hs_err*log" -o -name "*.gdb" -o -name "*.log" -o -name command.gdb -o -name "heapstats_*" -o -name "test-failed" -o -name "test-succeeded" -o -name "tmp*" -o -name core \) -exec rm -fR {} \;
   rm -fR __pycache__
   exit
 fi

--- a/agent/test/race-condition/testcase.sh
+++ b/agent/test/race-condition/testcase.sh
@@ -1,3 +1,39 @@
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
+<< LICENSE
+Copyright (C) 2017 Nippon Telegraph and Telephone Corporation
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+LICENSE
+
 #!/bin/sh
 
 pushd $(dirname $0) >/dev/null

--- a/agent/test/race-condition/testlist.txt
+++ b/agent/test/race-condition/testlist.txt
@@ -1,1 +1,5 @@
 ClassPrepare/*
+MemoryExhausted/*
+ThreadExhausted/*
+SnapShotProcessor/*
+GCWatcher/*


### PR DESCRIPTION
We should add race condition tests to prevent potential bugs of core components.
This patch covers the following events.
 * ClassPrepare
 * MemoryExhausted
 * ThreadExhausted
 * SnapShotProcessor
 * GCWatcher

icedtea: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3406