### PR TITLE
Bug 3407:  [TEST] jcmd should not be run for safepoint in ThreadExhausted tests

### DIFF
--- a/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ClassPrepare/ThreadExhausted_safepoint/test.py
@@ -27,4 +27,4 @@ def Cond_OnClassPrepare():
     return (symbol.find("DynLoad") != -1)
 
 
-common.initialize("OnClassPrepare", Cond_OnClassPrepare, "OnResourceExhausted", common.return_true, True, False, True)
+common.initialize("OnClassPrepare", Cond_OnClassPrepare, "OnResourceExhausted", common.return_true, True, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/GCWatcher/ThreadExhausted_safepoint/test.py
@@ -21,4 +21,4 @@ sys.path.append(os.pardir + "/../")
 
 import common
 
-common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True, True, True)
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, True, True, True, False)

--- a/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/MemoryExhausted/ThreadExhausted_safepoint/test.py
@@ -36,4 +36,4 @@ def Cond_MemoryExhausted():
 def Cond_ThreadExhausted():
   return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
 
-common.initialize("OnResourceExhausted", Cond_MemoryExhausted, "OnResourceExhausted", Cond_ThreadExhausted, True, False, True)
+common.initialize("OnResourceExhausted", Cond_MemoryExhausted, "OnResourceExhausted", Cond_ThreadExhausted, True, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/SnapShotProcessor/ThreadExhausted_safepoint/test.py
@@ -21,4 +21,4 @@ sys.path.append(os.pardir + "/../")
 
 import common
 
-common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)
+common.initialize("TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, "OnResourceExhausted", common.return_true, False, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/GCWatcher_safepoint/test.py
@@ -22,4 +22,4 @@ sys.path.append(os.pardir + "/../")
 import common
 
 
-common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)
+common.initialize("OnResourceExhausted", common.return_true, "TGCWatcher::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/MemoryExhausted_safepoint/test.py
@@ -36,4 +36,4 @@ def Cond_MemoryExhausted():
 def Cond_ThreadExhausted():
   return ((flagToInt() & JVMTI_RESOURCE_EXHAUSTED_THREADS) != 0)
 
-common.initialize("OnResourceExhausted", Cond_ThreadExhausted, "OnResourceExhausted", Cond_MemoryExhausted, True, False, True)
+common.initialize("OnResourceExhausted", Cond_ThreadExhausted, "OnResourceExhausted", Cond_MemoryExhausted, True, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/OnClassPrepare_safepoint/test.py
@@ -27,4 +27,4 @@ def Cond_OnClassPrepare():
     return (symbol.find("DynLoad") != -1)
 
 
-common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, False, True)
+common.initialize("OnResourceExhausted", common.return_true, "OnClassPrepare", Cond_OnClassPrepare, True, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/SnapShotProcessor_safepoint/test.py
@@ -21,4 +21,4 @@ sys.path.append(os.pardir + "/../")
 
 import common
 
-common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, False, True)
+common.initialize("OnResourceExhausted", common.return_true, "TSnapShotProcessor::entryPoint:RACE_COND_DEBUG_POINT", common.return_true, False, at_safepoint=True, jcmd_for_safepoint=False)

--- a/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
+++ b/agent/test/race-condition/ThreadExhausted/ThreadExhausted_safepoint/test.py
@@ -21,4 +21,4 @@ sys.path.append(os.pardir + "/../")
 
 import common
 
-common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False, False, True)
+common.initialize("OnResourceExhausted", common.return_true, "OnResourceExhausted", common.return_true, False, at_safepoint=True, jcmd_for_safepoint=False)


### PR DESCRIPTION
This PR is for [Bug 3407](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3407).

We use `jcmd GC.run` to occur at safepoint execution.
However, ThreadExhausted tests will consume all process resources. It might show PythonException message in GDB console.

We should fix not to show PythonException when starting jcmd is failed.