### PR TITLE
Bug 3416: Remove inheritance from each modules

### DIFF
--- a/analyzer/cli/pom.xml
+++ b/analyzer/cli/pom.xml
@@ -20,13 +20,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-cli</artifactId>
     <version>2.1-SNAPSHOT</version>

--- a/analyzer/core/pom.xml
+++ b/analyzer/core/pom.xml
@@ -20,13 +20,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-core</artifactId>
     <version>2.1-SNAPSHOT</version>

--- a/analyzer/fx/pom.xml
+++ b/analyzer/fx/pom.xml
@@ -20,13 +20,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <artifactId>heapstats</artifactId>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <version>2.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-analyzer</artifactId>
     <version>2.1-SNAPSHOT</version>

--- a/analyzer/jmx-helper/pom.xml
+++ b/analyzer/jmx-helper/pom.xml
@@ -20,13 +20,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-jmx-helper</artifactId>
     <version>2.1-SNAPSHOT</version>

--- a/mbean/java/pom.xml
+++ b/mbean/java/pom.xml
@@ -20,13 +20,6 @@
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>jp.co.ntt.oss.heapstats</groupId>
-        <artifactId>heapstats</artifactId>
-        <version>2.1-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
-    </parent>
-
     <groupId>jp.co.ntt.oss.heapstats</groupId>
     <artifactId>heapstats-mbean</artifactId>
     <version>2.1-SNAPSHOT</version>


### PR DESCRIPTION
All modules of HeapStats analyzer have the inheritance to load dependencies. However, all modules had defined the dependencies of each module already, so we had better remove inheritance.

@seealso
https://maven.apache.org/pom.html#Inheritance
http://books.sonatype.com/mvnref-book/reference/pom-relationships-sect-pom-best-practice.html

icedtea: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3416