### PR TITLE
Bug 3418: [TEST] GCWatcher and SnapShotProcessor tests might hang

### DIFF
--- a/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
+++ b/agent/test/race-condition/GCWatcher/SnapShotProcessor/testcase/Test.java
@@ -20,6 +20,7 @@ public class Test{
 
   public static void main(String[] args) throws Exception{
     System.gc();
+    Thread.sleep(3000); // Sleep 3 sec to wait breakpoint...
     System.gc();
   }
 

--- a/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
+++ b/agent/test/race-condition/SnapShotProcessor/GCWatcher/testcase/Test.java
@@ -38,6 +38,7 @@ public class Test{
 
   public static void main(String[] args) throws Exception{
     System.gc();
+    Thread.sleep(3000); // Sleep 3 sec to wait breakpoint...
     System.gc();
   }
 


### PR DESCRIPTION
This PR is for [Bug 3418](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3418).

Agent tests `race-condition/GCWatcher/SnapShotProcessor` and `race-condition/SnapShotProcessor/GCWatcher` might hang because these Java test code executes two `System.gc()` calls without any sleep/locks.
These testcases disable secondary breakpoint. So it might not hit if the process reaches this point before GDB enable secondary breakpoint.

So we should add sleep code between two `System.gc()` calls.