### PR TITLE
Bug 3419: Provide FXAnalyzer RPM package for Fedora

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,8 +3,8 @@ SUBDIRS = agent mbean
 MVN = @MVN@
 JAVA_HOME = @JDK_DIR@
 
-ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-$(PACKAGE_VERSION)-bin/heapstats-analyzer-$(PACKAGE_VERSION)
-CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-$(PACKAGE_VERSION)-bin/heapstats-cli-$(PACKAGE_VERSION)
+ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-*-bin/heapstats-analyzer-*
+CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-*-bin/heapstats-cli-*
 
 .PHONY: $(SUBDIRS) analyzer
 
@@ -36,8 +36,9 @@ install-exec-local:
 	$(INSTALL_DATA) $(ANALYZER_DIR)/lib/jgraphx.jar $(DESTDIR)/$(libexecdir)/lib
 	$(INSTALL_DATA) $(CLI_DIR)/heapstats-cli.jar $(DESTDIR)/$(libexecdir)
 	$(INSTALL_PROGRAM) $(srcdir)/analyzer/cli/heapstats-cli $(DESTDIR)/$(bindir)
+	$(INSTALL_PROGRAM) $(srcdir)/analyzer/fx/heapstats-analyzer $(DESTDIR)/$(bindir)
 
 uninstall-local:
 	rm -fR $(DESTDIR)/$(libexecdir)/lib
-	$(RM) $(DESTDIR)/$(libexecdir)/THIRD_PARTY_README $(DESTDIR)/$(libexecdir)/filterDefine.xsd $(DESTDIR)/$(libexecdir)/heapstats* $(DESTDIR)/$(bindir)/heapstats-cli
+	$(RM) $(DESTDIR)/$(libexecdir)/THIRD_PARTY_README $(DESTDIR)/$(libexecdir)/filterDefine.xsd $(DESTDIR)/$(libexecdir)/heapstats* $(DESTDIR)/$(bindir)/heapstats-cli  $(DESTDIR)/$(bindir)/heapstats-analyzer
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -98,7 +98,8 @@ DIST_COMMON = $(srcdir)/Makefile.am $(top_srcdir)/configure \
 am__CONFIG_DISTCLEAN_FILES = config.status config.cache config.log \
  configure.lineno config.status.lineno
 mkinstalldirs = $(install_sh) -d
-CONFIG_CLEAN_FILES = analyzer/cli/heapstats-cli
+CONFIG_CLEAN_FILES = analyzer/cli/heapstats-cli \
+	analyzer/fx/heapstats-analyzer
 CONFIG_CLEAN_VPATH_FILES =
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -159,7 +160,8 @@ DIST_SUBDIRS = $(SUBDIRS)
 am__DIST_COMMON = $(srcdir)/Makefile.in $(top_srcdir)/./m4/compile \
 	$(top_srcdir)/./m4/config.guess $(top_srcdir)/./m4/config.sub \
 	$(top_srcdir)/./m4/install-sh $(top_srcdir)/./m4/missing \
-	$(top_srcdir)/analyzer/cli/heapstats-cli.in ./m4/compile \
+	$(top_srcdir)/analyzer/cli/heapstats-cli.in \
+	$(top_srcdir)/analyzer/fx/heapstats-analyzer.in ./m4/compile \
 	./m4/config.guess ./m4/config.sub ./m4/depcomp ./m4/install-sh \
 	./m4/missing AUTHORS COPYING ChangeLog INSTALL NEWS README
 DISTFILES = $(DIST_COMMON) $(DIST_SOURCES) $(TEXINFOS) $(EXTRA_DIST)
@@ -322,8 +324,8 @@ top_srcdir = @top_srcdir@
 ACLOCAL_AMFLAGS = -I ./m4
 SUBDIRS = agent mbean
 JAVA_HOME = @JDK_DIR@
-ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-$(PACKAGE_VERSION)-bin/heapstats-analyzer-$(PACKAGE_VERSION)
-CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-$(PACKAGE_VERSION)-bin/heapstats-cli-$(PACKAGE_VERSION)
+ANALYZER_DIR = $(srcdir)/analyzer/fx/target/heapstats-analyzer-*-bin/heapstats-analyzer-*
+CLI_DIR = $(srcdir)/analyzer/cli/target/heapstats-cli-*-bin/heapstats-cli-*
 all: all-recursive
 
 .SUFFIXES:
@@ -361,6 +363,8 @@ $(ACLOCAL_M4): @MAINTAINER_MODE_TRUE@ $(am__aclocal_m4_deps)
 	$(am__cd) $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
 $(am__aclocal_m4_deps):
 analyzer/cli/heapstats-cli: $(top_builddir)/config.status $(top_srcdir)/analyzer/cli/heapstats-cli.in
+	cd $(top_builddir) && $(SHELL) ./config.status $@
+analyzer/fx/heapstats-analyzer: $(top_builddir)/config.status $(top_srcdir)/analyzer/fx/heapstats-analyzer.in
 	cd $(top_builddir) && $(SHELL) ./config.status $@
 
 # This directory's subdirectories are mostly independent; you can cd
@@ -811,10 +815,11 @@ install-exec-local:
 	$(INSTALL_DATA) $(ANALYZER_DIR)/lib/jgraphx.jar $(DESTDIR)/$(libexecdir)/lib
 	$(INSTALL_DATA) $(CLI_DIR)/heapstats-cli.jar $(DESTDIR)/$(libexecdir)
 	$(INSTALL_PROGRAM) $(srcdir)/analyzer/cli/heapstats-cli $(DESTDIR)/$(bindir)
+	$(INSTALL_PROGRAM) $(srcdir)/analyzer/fx/heapstats-analyzer $(DESTDIR)/$(bindir)
 
 uninstall-local:
 	rm -fR $(DESTDIR)/$(libexecdir)/lib
-	$(RM) $(DESTDIR)/$(libexecdir)/THIRD_PARTY_README $(DESTDIR)/$(libexecdir)/filterDefine.xsd $(DESTDIR)/$(libexecdir)/heapstats* $(DESTDIR)/$(bindir)/heapstats-cli
+	$(RM) $(DESTDIR)/$(libexecdir)/THIRD_PARTY_README $(DESTDIR)/$(libexecdir)/filterDefine.xsd $(DESTDIR)/$(libexecdir)/heapstats* $(DESTDIR)/$(bindir)/heapstats-cli  $(DESTDIR)/$(bindir)/heapstats-analyzer
 
 # Tell versions [3.59,3.63) of GNU make to not export all variables.
 # Otherwise a system limit (for SysV at least) may be exceeded.

--- a/analyzer/fx/heapstats-analyzer.in
+++ b/analyzer/fx/heapstats-analyzer.in
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libexecdir=@libexecdir@
+
+ANALYZER_JAR="$libexecdir/heapstats-analyzer.jar"
+
+if test -x $JAVA_HOME/bin/java; then
+  $JAVA_HOME/bin/java $JAVA_OPTS -jar $ANALYZER_JAR $@
+elif test -z "$JAVA_HOME"; then
+  echo "Set \$JAVA_HOME to run heapstats-analyzer"
+else
+  echo "Set \$JAVA_HOME correctly to run heapstats-analyzer"
+fi
+

--- a/analyzer/fx/pom.xml
+++ b/analyzer/fx/pom.xml
@@ -141,6 +141,7 @@
                             <Class-Path>lib/jgraphx.jar</Class-Path>
                         </manifestEntries>
                     </archive>
+                    <finalName>heapstats-analyzer</finalName>
                 </configuration>
             </plugin>
             <plugin>

--- a/configure
+++ b/configure
@@ -8664,7 +8664,7 @@ fi
 
 # end of configure attacher  ---------------------------------------------------
 
-ac_config_files="$ac_config_files Makefile agent/Makefile agent/src/Makefile agent/src/heapstats-engines/Makefile agent/attacher/Makefile agent/attacher/heapstats-attacher agent/src/iotracer/Makefile mbean/Makefile mbean/native/Makefile analyzer/cli/heapstats-cli"
+ac_config_files="$ac_config_files Makefile agent/Makefile agent/src/Makefile agent/src/heapstats-engines/Makefile agent/attacher/Makefile agent/attacher/heapstats-attacher agent/src/iotracer/Makefile mbean/Makefile mbean/native/Makefile analyzer/cli/heapstats-cli analyzer/fx/heapstats-analyzer"
 
 ac_config_files="$ac_config_files agent/heapstats.conf"
 
@@ -9478,6 +9478,7 @@ do
     "mbean/Makefile") CONFIG_FILES="$CONFIG_FILES mbean/Makefile" ;;
     "mbean/native/Makefile") CONFIG_FILES="$CONFIG_FILES mbean/native/Makefile" ;;
     "analyzer/cli/heapstats-cli") CONFIG_FILES="$CONFIG_FILES analyzer/cli/heapstats-cli" ;;
+    "analyzer/fx/heapstats-analyzer") CONFIG_FILES="$CONFIG_FILES analyzer/fx/heapstats-analyzer" ;;
     "agent/heapstats.conf") CONFIG_FILES="$CONFIG_FILES agent/heapstats.conf" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -402,7 +402,7 @@ fi
 
 # end of configure attacher  ---------------------------------------------------
 
-AC_CONFIG_FILES([Makefile agent/Makefile agent/src/Makefile agent/src/heapstats-engines/Makefile agent/attacher/Makefile agent/attacher/heapstats-attacher agent/src/iotracer/Makefile mbean/Makefile mbean/native/Makefile analyzer/cli/heapstats-cli])
+AC_CONFIG_FILES([Makefile agent/Makefile agent/src/Makefile agent/src/heapstats-engines/Makefile agent/attacher/Makefile agent/attacher/heapstats-attacher agent/src/iotracer/Makefile mbean/Makefile mbean/native/Makefile analyzer/cli/heapstats-cli analyzer/fx/heapstats-analyzer])
 AC_CONFIG_FILES([agent/heapstats.conf])
 
 AC_OUTPUT

--- a/specs/heapstats.spec
+++ b/specs/heapstats.spec
@@ -12,6 +12,11 @@ Source: heapstats-%{version}.tar.gz
 #Patch0: none
 Buildroot: /var/tmp/heapstats
 
+# Check OpenJFX supported platform
+%if %{?fedora:%{fedora}}%{!?fedora:0} >= 26
+%define WITH_ANALYZER 1
+%endif
+
 # Requires for running
 Requires: pcre >= 6
 
@@ -23,12 +28,24 @@ BuildRequires: binutils >= 2
 BuildRequires: binutils-devel
 BuildRequires: autoconf
 BuildRequires: automake
-BuildRequires: maven
+
+%if 0%{?WITH_ANALYZER:1}
+BuildRequires: java-1.8.0-openjdk-openjfx-devel
+%endif
 
 %package cli
 Summary:   HeapStats CLI
 Group:     Development/Tools
 BuildArch: noarch
+
+%if 0%{?WITH_ANALYZER:1}
+%package analyzer
+Summary:   HeapStats Analyzer
+Group:     Development/Tools
+BuildArch: noarch
+Requires: java-1.8.0-openjdk-openjfx
+Requires: heapstats-cli
+%endif
 
 %description
 A lightweight monitoring JVMTI agent for Java HotSpot VM.
@@ -37,6 +54,12 @@ Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation.
 %description cli
 Commandline analysis tool for HeapStats.
 Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation.
+
+%if 0%{?WITH_ANALYZER:1}
+%description analyzer
+HeapStats GUI Analyzer
+Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation.
+%endif
 
 %prep
 %setup -q -n heapstats-2.0
@@ -56,30 +79,40 @@ CXXFLAGS="$RPM_OPT_FLAGS" ./configure \
   --enable-optimize \
   --without-gcov \
   --disable-profile 
-make agent mbean RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
-mvn -am -pl analyzer/cli package
+
+%if 0%{?WITH_ANALYZER:1}
+  make
+%else
+  make agent mbean RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
+  mvn -am -pl analyzer/cli package
+%endif
 
 %install
 rm -rf $RPM_BUILD_ROOT
-mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/heapstats
-cd agent
-make install DESTDIR=${RPM_BUILD_ROOT}
-cd ../mbean
-make install DESTDIR=${RPM_BUILD_ROOT}
-cd ../
 mkdir -p $RPM_BUILD_ROOT/etc/ld.so.conf.d/
 echo "%{_libdir}/heapstats" \
   >> $RPM_BUILD_ROOT/etc/ld.so.conf.d/heapstats-agent.conf
 mkdir -p $RPM_BUILD_ROOT/usr/share/snmp/mibs/
 cp ./agent/mib/HeapStatsMibs.txt $RPM_BUILD_ROOT/usr/share/snmp/mibs/
 
-# We do not privide FX analyzer.
-# So we install CLI analyzer manually.
-mkdir -p ${RPM_BUILD_ROOT}/%{_libexecdir}/heapstats
-cp -fR ./analyzer/cli/target/heapstats-cli-*-bin/heapstats-cli-*/* \
+%if 0%{?WITH_ANALYZER:1}
+  make install DESTDIR=${RPM_BUILD_ROOT}
+%else
+  mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/heapstats
+  cd agent
+  make install DESTDIR=${RPM_BUILD_ROOT}
+  cd ../mbean
+  make install DESTDIR=${RPM_BUILD_ROOT}
+  cd ../
+
+  # We do not privide FX analyzer.
+  # So we install CLI analyzer manually.
+  mkdir -p ${RPM_BUILD_ROOT}/%{_libexecdir}/heapstats
+  cp -fR ./analyzer/cli/target/heapstats-cli-*-bin/heapstats-cli-*/* \
                                     ${RPM_BUILD_ROOT}%{_libexecdir}/heapstats/
-cp -f ./analyzer/cli/heapstats-cli ${RPM_BUILD_ROOT}%{_bindir}
-chmod a+x ${RPM_BUILD_ROOT}%{_bindir}/heapstats-cli
+  cp -f ./analyzer/cli/heapstats-cli ${RPM_BUILD_ROOT}%{_bindir}
+  chmod a+x ${RPM_BUILD_ROOT}%{_bindir}/heapstats-cli
+%endif
 
 %post
 /sbin/ldconfig
@@ -121,8 +154,19 @@ rm -rf $RPM_BUILD_ROOT
 %{_libexecdir}/heapstats/lib/heapstats-mbean.jar
 %{_libexecdir}/heapstats/lib/heapstats-jmx-helper.jar
 
+%if 0%{?WITH_ANALYZER:1}
+%files analyzer
+/usr/bin/heapstats-analyzer
+%{_libexecdir}/heapstats/heapstats-analyzer.jar
+%{_libexecdir}/heapstats/THIRD_PARTY_README
+%{_libexecdir}/heapstats/filterDefine.xsd
+%{_libexecdir}/heapstats/heapstats.properties
+%{_libexecdir}/heapstats/lib/jgraphx.jar
+%endif
 
 %changelog
+* Tue Jul 11 2017 Yasumasa Suenaga <yasuenag@gmail.com>
+- Add Analyzer package.
 * Tue Feb 09 2016 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
 - Set version to 2.0.trunk
 * Thu Oct 22 2015 Yasumasa Suenaga <yasuenag@gmail.com>


### PR DESCRIPTION
This PR is for [Bug 3419](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3419).

ince Fedora 26, OpenJFX is provided from Fedora repository.
HeapStats (FX) Analyzer uses JavaFX, and it works fine with OpenJFX.

So we can provide FXAnalyzer RPM package for Fedora.

Bug 1145303 - RFE: JavaFX:
  https://bugzilla.redhat.com/show_bug.cgi?id=1145303