### PR TITLE
Bug 3421: Override functions might crash on Fedora 26

### DIFF
--- a/agent/src/heapstats-engines/arch/x86/overrideFunc.amd64.S
+++ b/agent/src/heapstats-engines/arch/x86/overrideFunc.amd64.S
@@ -3,7 +3,7 @@
  * \brief This file is used to override JVM inner function for AMD64.<br>
  *        The function defined this file, used with v-table hook.<br>
  *        So in this file, all function is written by only assembler and macro.
- * Copyright (C) 2014-2015 Yasumasa Suenaga
+ * Copyright (C) 2014-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -58,13 +58,19 @@
   mov collectedHeap@GOTPCREL(%rip), %rdi;   \
   mov (%rdi), %rdi;                         \
   mov oop_ofs(%rsp), %rsi;                  \
+  push %rbp;                                \
+  mov %rsp, %rbp;                           \
   call *(%r11);                             \
+  pop %rbp;                                 \
   test %al, %al;                            
 
 #define DO_JMP_TO_CALLBACK(header, ary_idx, oop_ofs) \
   mov oop_ofs(%rsp), %rdi;                                  \
   mov header##_enter_hook_##ary_idx##@GOTPCREL(%rip), %r11; \
-  call *(%r11);
+  push %rbp;                                                \
+  mov %rsp, %rbp;                                           \
+  call *(%r11);                                             \
+  pop %rbp;
 
 #define OVERRIDE_FUNC_DEFINE(header, ary_idx) \
 .global header##_override_func_##ary_idx ;                     \


### PR DESCRIPTION
This PR is for [Bug 3421](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3421).

On Fedora 26 x86_64, HeapStats Agent might crash.
I investigated with GDB, it seems to be heap corruption.

In assembler override functions, HeapStats Agent will call some function(s) in libjvm.so with `call` instruction.

According to [Intel(R) 64 and IA-32 Architectures Software Developer’s Manual](https://software.intel.com/en-us/articles/intel-sdm), `call` and `ret` instructions will not modify base pointer ( `bp` ). So I did not save base pointer before subroutine call.

I guess GCC 7.1 which is provided by Fedora 26 generates binaries which more depends on base pointer than previous releases. So we should save base pointer before any `call` instruction, and it should be recovered after that.


I will fix it for AMD64 only because calling convention for x86 (32bit architecture) depends on stack memory. So it might not occur on x86 platform.
For ARM (Raspbian), I did not confirm this crash.

If we encounter this crash on other platform, I will reopen this ticket and fix it.