### PR TITLE
Bug 3422: [REFACTORING] Stack and base pointer operation

### DIFF
--- a/agent/src/heapstats-engines/arch/x86/overrideFunc.amd64.S
+++ b/agent/src/heapstats-engines/arch/x86/overrideFunc.amd64.S
@@ -58,24 +58,20 @@
   mov collectedHeap@GOTPCREL(%rip), %rdi;   \
   mov (%rdi), %rdi;                         \
   mov oop_ofs(%rsp), %rsi;                  \
-  push %rbp;                                \
-  mov %rsp, %rbp;                           \
   call *(%r11);                             \
-  pop %rbp;                                 \
   test %al, %al;                            
 
 #define DO_JMP_TO_CALLBACK(header, ary_idx, oop_ofs) \
   mov oop_ofs(%rsp), %rdi;                                  \
   mov header##_enter_hook_##ary_idx##@GOTPCREL(%rip), %r11; \
-  push %rbp;                                                \
-  mov %rsp, %rbp;                                           \
-  call *(%r11);                                             \
-  pop %rbp;
+  call *(%r11);
 
 #define OVERRIDE_FUNC_DEFINE(header, ary_idx) \
 .global header##_override_func_##ary_idx ;                     \
 .type header##_override_func_##ary_idx, @function;             \
 header##_override_func_##ary_idx: ;                            \
+  push %rbp;                                                   \
+  mov %rsp, %rbp;                                              \
   /* Save argument registers. */ ;                             \
   DO_SAVE_REG                                                  \
                                                                \
@@ -138,5 +134,11 @@ header##_override_func_##ary_idx: ;                            \
 .LORIGINAL_FUNC:
   pop %r11;
   DO_LOAD_REG
+
+  /* Restore stack pointer */
+  mov %rbp, %rsp;
+  /* Restore base pointer */
+  pop %rbp;
+
   jmp *%r11;
 


### PR DESCRIPTION
This PR is for [Bug 3422](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3422).

In [Bug 3421](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3421) (GitHub PR #110 ) fixes invalid stack pointer address.
It causes SP is not aligned 16-byte. According to [Intel discussion forum](https://software.intel.com/en-us/forums/intel-isa-extensions/topic/291241), SP should be aligned 16-byte.

Currently, HeapStats Agent align SP before any `call` instruction call. So crash has gone.
But it is difficult to read. So I want to refactor to fix pointer address at the top of override functions.