### PR TITLE
Bug 3424: HeapStats Agent might crash when thread recorder is disabled via realoading configuration

### DIFF
--- a/agent/src/heapstats-engines/jniCallbackRegister.hpp
+++ b/agent/src/heapstats-engines/jniCallbackRegister.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file jniCallbackRegister.hpp
  * \brief Handling JNI function callback.
- * Copyright (C) 2015 Yasumasa Suenaga
+ * Copyright (C) 2015-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -24,6 +24,8 @@
 
 #include <jvmti.h>
 #include <jni.h>
+
+#include <pthread.h>
 
 #include <list>
 
@@ -51,6 +53,11 @@ class TJNICallbackRegister {
    */
   static std::list<T> epilogueCallbackList;
 
+  /*!
+   * \brief Read-Write lock for callback container.
+   */
+  static pthread_rwlock_t callbackLock;
+
  public:
   /*!
    * \brief Register callbacks for JNI function.
@@ -59,13 +66,49 @@ class TJNICallbackRegister {
    * \param epilogue [in] Callback after calling JNI function.
    */
   static void registerCallback(T prologue, T epilogue) {
-    if (prologue != NULL) {
-      prologueCallbackList.push_back(prologue);
-    }
+    pthread_rwlock_wrlock(&callbackLock);
+    {
+      if (prologue != NULL) {
+        prologueCallbackList.push_back(prologue);
+      }
 
-    if (epilogue != NULL) {
-      epilogueCallbackList.push_back(epilogue);
+      if (epilogue != NULL) {
+        epilogueCallbackList.push_back(epilogue);
+      }
     }
+    pthread_rwlock_unlock(&callbackLock);
+  };
+
+  /*!
+   * \brief Unegister callbacks for JNI function.
+   *
+   * \param prologue [in] Callback before calling JNI function.
+   * \param epilogue [in] Callback after calling JNI function.
+   */
+  static void unregisterCallback(T prologue, T epilogue) {
+    pthread_rwlock_wrlock(&callbackLock);
+    {
+      if (prologue != NULL) {
+        for (auto itr = prologueCallbackList.cbegin();
+             itr != prologueCallbackList.cend(); itr++) {
+          if (prologue == *itr) {
+            prologueCallbackList.erase(itr);
+            break;
+          }
+        }
+      }
+
+      if (epilogue != NULL) {
+        for (auto itr = epilogueCallbackList.cbegin();
+             itr != epilogueCallbackList.cend(); itr++) {
+          if (epilogue == *itr) {
+            epilogueCallbackList.erase(itr);
+            break;
+          }
+        }
+      }
+    }
+    pthread_rwlock_unlock(&callbackLock);
   };
 };
 
@@ -81,20 +124,35 @@ std::list<T> TJNICallbackRegister<T>::prologueCallbackList;
 template <typename T>
 std::list<T> TJNICallbackRegister<T>::epilogueCallbackList;
 
+/*!
+ * \brief Read-Write lock for callback container.
+ */
+template <typename T>
+pthread_rwlock_t TJNICallbackRegister<T>::callbackLock =
+                                              PTHREAD_RWLOCK_INITIALIZER;
+
 #define ITERATE_JNI_CALLBACK_CHAIN(type, originalFunc, ...)                   \
   std::list<type>::iterator itr;                                              \
                                                                               \
-  for (itr = prologueCallbackList.begin(); itr != prologueCallbackList.end(); \
-       itr++) {                                                               \
-    (*itr)(__VA_ARGS__);                                                      \
+  pthread_rwlock_rdlock(&callbackLock);                                       \
+  {                                                                           \
+    for (itr = prologueCallbackList.begin();                                  \
+         itr != prologueCallbackList.end(); itr++) {                          \
+      (*itr)(__VA_ARGS__);                                                    \
+    }                                                                         \
   }                                                                           \
+  pthread_rwlock_unlock(&callbackLock);                                       \
                                                                               \
   originalFunc(__VA_ARGS__);                                                  \
                                                                               \
-  for (itr = epilogueCallbackList.begin(); itr != epilogueCallbackList.end(); \
-       itr++) {                                                               \
-    (*itr)(__VA_ARGS__);                                                      \
-  }
+  pthread_rwlock_rdlock(&callbackLock);                                       \
+  {                                                                           \
+    for (itr = epilogueCallbackList.begin();                                  \
+         itr != epilogueCallbackList.end(); itr++) {                          \
+      (*itr)(__VA_ARGS__);                                                    \
+    }                                                                         \
+  }                                                                           \
+  pthread_rwlock_unlock(&callbackLock);
 
 /*!
  * \brief JVM_Sleep callback (java.lang.System#sleep())

--- a/agent/src/heapstats-engines/threadRecorder.cpp
+++ b/agent/src/heapstats-engines/threadRecorder.cpp
@@ -614,17 +614,12 @@ void TThreadRecorder::UnregisterIOTracer(JNIEnv *env) {
  * \param buf_sz [in] Size of ring buffer.
  */
 void TThreadRecorder::initialize(jvmtiEnv *jvmti, JNIEnv *env, size_t buf_sz) {
-  static bool isRegistered = false;
-
   if (likely(inst == NULL)) {
     inst = new TThreadRecorder(buf_sz);
 
-    if (!isRegistered) {
-      isRegistered = true;
-      registerHookPoint(jvmti, env);
-      registerJNIHookPoint(env);
-      registerIOTracer(jvmti, env);
-    }
+    registerHookPoint(jvmti, env);
+    registerJNIHookPoint(env);
+    registerIOTracer(jvmti, env);
 
     inst->registerAllThreads(jvmti);
   }
@@ -694,20 +689,39 @@ void TThreadRecorder::dump(const char *fname) {
  */
 void TThreadRecorder::finalize(jvmtiEnv *jvmti, JNIEnv *env,
                                const char *fname) {
-  /* Stop to hook JVMTI event */
+  /* Stop JVMTI events which are used by ThreadRecorder only. */
   TThreadStartCallback::switchEventNotification(jvmti, JVMTI_DISABLE);
   TThreadEndCallback::switchEventNotification(jvmti, JVMTI_DISABLE);
-  TMonitorContendedEnterCallback::switchEventNotification(jvmti, JVMTI_DISABLE);
   TMonitorContendedEnteredCallback::switchEventNotification(jvmti,
                                                             JVMTI_DISABLE);
   TMonitorWaitCallback::switchEventNotification(jvmti, JVMTI_DISABLE);
   TMonitorWaitedCallback::switchEventNotification(jvmti, JVMTI_DISABLE);
 
-  /* Stop to hook JNI function */
+  /* Stop JNI function hooks. */
   TJVMSleepCallback::switchCallback(env, false);
   TUnsafeParkCallback::switchCallback(env, false);
 
-  /* Stop to hook IoTrace */
+  /* Unregister JVMTI event callbacks which are used by ThreadRecorder. */
+  TThreadStartCallback::unregisterCallback(&OnThreadStart);
+  TThreadEndCallback::unregisterCallback(&OnThreadEnd);
+  TMonitorContendedEnterCallback::unregisterCallback(
+      &OnMonitorContendedEnterForThreadRecording);
+  TMonitorContendedEnteredCallback::unregisterCallback(
+      &OnMonitorContendedEnteredForThreadRecording);
+  TMonitorWaitCallback::unregisterCallback(&OnMonitorWait);
+  TMonitorWaitedCallback::unregisterCallback(&OnMonitorWaited);
+  TDataDumpRequestCallback::unregisterCallback(
+      &OnDataDumpRequestForDumpThreadRecordData);
+
+  /* Refresh JVMTI event callbacks */
+  registerJVMTICallbacks(jvmti);
+
+  /* Unregister JNI function hooks which are used by ThreadRecorder. */
+  TJVMSleepCallback::unregisterCallback(&JVM_SleepPrologue, &JVM_SleepEpilogue);
+  TUnsafeParkCallback::unregisterCallback(&UnsafeParkPrologue,
+                                          &UnsafeParkEpilogue);
+
+  /* Stop IoTrace hook */
   UnregisterIOTracer(env);
 
   /* Wait until all tasks are finished. */


### PR DESCRIPTION
This PR is for [Bug 3424](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3424).

HeapStats Agent might crash when you want to disable Thread Recorder via reloading configuration.


# How To Reproduce

1. Start [SleepLoop.java](http://icedtea.classpath.org/bugzilla/attachment.cgi?id=1635) with Thread Recorder (set `thread_record_enable` in `heapstats.conf` to `true` )
2. Change `thread_record_enable` in `heapstats.conf` to `false`
3. Send `SIGHUP` to the `SleepLoop` process



# Evaluation

Reloading signal will disable all hook points in HeapStas Agent. However, it will not unregister hook points in `callbackRegister.hpp` and `jniCallbackRegister.hpp` . So process crash might occur when the epilogue hook of `JVM_Sleep()` is called after disabling Thread Recorder.

We should unregister all hooks for Thread Recorder at `TThreadRecorder::finalize()` .