### PR TITLE
Bug 3429: [REGRESSION] Cannot build HeapStats Agent on RHEL

### DIFF
--- a/agent/src/heapstats-engines/callbackRegister.hpp
+++ b/agent/src/heapstats-engines/callbackRegister.hpp
@@ -66,8 +66,15 @@ class TJVMTIEventCallback {
   static void unregisterCallback(T callback) {
     pthread_rwlock_wrlock(&callbackLock);
     {
-      for (auto itr = callbackList.cbegin();
-           itr != callbackList.cend(); itr++) {
+#if __cplusplus >= 201103L
+      // C++11 support
+      auto list_begin = callbackList.cbegin();
+      auto list_end = callbackList.cend();
+#else
+      auto list_begin = callbackList.begin();
+      auto list_end = callbackList.end();
+#endif
+      for (auto itr = list_begin; itr != list_end; itr++) {
         if (*itr == callback) {
           callbackList.erase(itr);
           break;

--- a/agent/src/heapstats-engines/callbackRegister.hpp
+++ b/agent/src/heapstats-engines/callbackRegister.hpp
@@ -66,7 +66,7 @@ class TJVMTIEventCallback {
   static void unregisterCallback(T callback) {
     pthread_rwlock_wrlock(&callbackLock);
     {
-#if __cplusplus >= 201103L
+#ifdef USE_N2350
       // C++11 support
       auto list_begin = callbackList.cbegin();
       auto list_end = callbackList.cend();

--- a/agent/src/heapstats-engines/jniCallbackRegister.hpp
+++ b/agent/src/heapstats-engines/jniCallbackRegister.hpp
@@ -89,8 +89,15 @@ class TJNICallbackRegister {
     pthread_rwlock_wrlock(&callbackLock);
     {
       if (prologue != NULL) {
-        for (auto itr = prologueCallbackList.cbegin();
-             itr != prologueCallbackList.cend(); itr++) {
+#if __cplusplus >= 201103L
+        // C++11 support
+        auto prologue_begin = prologueCallbackList.cbegin();
+        auto prologue_end = prologueCallbackList.cend();
+#else
+        auto prologue_begin = prologueCallbackList.begin();
+        auto prologue_end = prologueCallbackList.end();
+#endif
+        for (auto itr = prologue_begin; itr != prologue_end; itr++) {
           if (prologue == *itr) {
             prologueCallbackList.erase(itr);
             break;
@@ -99,8 +106,15 @@ class TJNICallbackRegister {
       }
 
       if (epilogue != NULL) {
-        for (auto itr = epilogueCallbackList.cbegin();
-             itr != epilogueCallbackList.cend(); itr++) {
+#if __cplusplus >= 201103L
+        // C++11 support
+        auto epilogue_begin = prologueCallbackList.cbegin();
+        auto epilogue_end = prologueCallbackList.cend();
+#else
+        auto epilogue_begin = prologueCallbackList.begin();
+        auto epilogue_end = prologueCallbackList.end();
+#endif
+        for (auto itr = epilogue_begin; itr != epilogue_end; itr++) {
           if (epilogue == *itr) {
             epilogueCallbackList.erase(itr);
             break;

--- a/agent/src/heapstats-engines/jniCallbackRegister.hpp
+++ b/agent/src/heapstats-engines/jniCallbackRegister.hpp
@@ -89,7 +89,7 @@ class TJNICallbackRegister {
     pthread_rwlock_wrlock(&callbackLock);
     {
       if (prologue != NULL) {
-#if __cplusplus >= 201103L
+#ifdef USE_N2350
         // C++11 support
         auto prologue_begin = prologueCallbackList.cbegin();
         auto prologue_end = prologueCallbackList.cend();
@@ -106,7 +106,7 @@ class TJNICallbackRegister {
       }
 
       if (epilogue != NULL) {
-#if __cplusplus >= 201103L
+#ifdef USE_N2350
         // C++11 support
         auto epilogue_begin = prologueCallbackList.cbegin();
         auto epilogue_end = prologueCallbackList.cend();

--- a/configure
+++ b/configure
@@ -6501,6 +6501,53 @@ else
 fi
 
 
+# Check Container insert/erase and iterator constness (N2350)
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for N2350" >&5
+$as_echo_n "checking for N2350... " >&6; }
+
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+      #include <list>
+
+int
+main ()
+{
+
+      std::list<int> test;
+      test.push_back(0);
+      test.erase(test.cbegin());
+
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_cxx_try_run "$LINENO"; then :
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+    $as_echo "#define USE_N2350 1" >>confdefs.h
+
+
+else
+
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
 # Check for atomic operation
 for ac_header in atomic
 do :

--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,26 @@ AC_RUN_IFELSE(
 )
 AM_CONDITIONAL(USE_PCRE, test -n "${ac_cv_header_pcre_h}")
 
+# Check Container insert/erase and iterator constness (N2350)
+AC_MSG_CHECKING([for N2350])
+
+AC_RUN_IFELSE(
+  [AC_LANG_PROGRAM(
+    [[
+      #include <list>
+    ]], [[
+      std::list<int> test;
+      test.push_back(0);
+      test.erase(test.cbegin());
+    ]]
+  )], [
+    AC_MSG_RESULT([yes])
+    AC_DEFINE(USE_N2350, 1)
+  ], [
+    AC_MSG_RESULT([no])
+  ]
+)
+
 # Check for atomic operation
 AC_CHECK_HEADERS([atomic], [],
 [


### PR DESCRIPTION
This PR is for [Bug 3429](http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3429).

@ykubota reports HeapStats Agent cannot be built on RHEL after Bug 3424 (GitHub PR #112 ) on GitHub issue #113.

This change uses `std::list.erase(const_iterator)` which is [defined since C++11](http://www.cplusplus.com/reference/list/list/erase/). However we cannot use this function with older GCC.
In older GCC, we should use `std::list.erase(iterator)` .

We can use `__cplusplus` macro to judge [we should use which `erase()`](https://stackoverflow.com/questions/5047971/how-do-i-check-for-c11-support).