### PR TITLE
Bug 3430: Fix potential error when conflict between VMDeath and class loading

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-08-02 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3430: Fix potential error when conflict between VMDeath and class loading
+
 2017-08-02 Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 3293: [REFACTORING] Realtime deadlock detector implementation

--- a/agent/src/heapstats-engines/snapShotMain.cpp
+++ b/agent/src/heapstats-engines/snapShotMain.cpp
@@ -149,6 +149,7 @@ jvmtiIterationControl JNICALL HeapObjectCallBack(jlong clsTag, jlong size,
  */
 void JNICALL
     OnClassPrepare(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
+  TProcessMark mark(processing);
 
   /*
    * Wait if VM is at a safepoint which includes safepoint synchronizing,
@@ -285,6 +286,8 @@ void onInnerGarbageCollectionInterrupt(void) {
  * \param jvmti [in] JVMTI environment object.
  */
 void JNICALL OnGarbageCollectionStart(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
+
   snapshotByGC = TSnapShotContainer::getInstance();
 
   /* Enable inner GC event. */
@@ -296,6 +299,8 @@ void JNICALL OnGarbageCollectionStart(jvmtiEnv *jvmti) {
  * \param jvmti [in] JVMTI environment object.
  */
 void JNICALL OnGarbageCollectionFinish(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
+
   /* Disable inner GC event. */
   setupHookForInnerGCEvent(false, NULL);
 
@@ -539,6 +544,8 @@ void HeapKlassAdjustCallback(void *oldOop, void *newOop) {
  * \param jvmti [in] JVMTI environment object.
  */
 void JNICALL OnCMSGCStart(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
+
   /* Get CMS state. */
   bool needShapShot = false;
   int cmsState = checkCMSState(gcStart, &needShapShot);
@@ -574,6 +581,8 @@ void JNICALL OnCMSGCStart(jvmtiEnv *jvmti) {
  * \param jvmti [in] JVMTI environment object.
  */
 void JNICALL OnCMSGCFinish(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
+
   /* Disable inner GC event. */
   setupHookForInnerGCEvent(false, NULL);
 
@@ -598,6 +607,8 @@ void JNICALL OnCMSGCFinish(jvmtiEnv *jvmti) {
  * \param jvmti [in] JVMTI environment object.
  */
 void JNICALL OnDataDumpRequestForSnapShot(jvmtiEnv *jvmti) {
+  TProcessMark mark(processing);
+
   /* Avoid the plural simultaneous take snapshot by dump-request.        */
   /* E.g. keeping pushed dump key.                                       */
   /* Because classContainer register a redundancy class in TakeSnapShot. */


### PR DESCRIPTION
HeapStats will get an error at corner case when conflict between VMDeath (Agent_OnUnload()) and class loading. We must fix it to finish JVM correctly.

icedtea: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3430