### PR TITLE
Bug 3437: Add support for JDK 9 Version-String Scheme (JEP 223)

### DIFF
--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -137,11 +137,11 @@ bool TJvmInfo::setHSVersion(jvmtiEnv *jvmti) {
     logger->printDebugMsg("HotSpot version: %s", versionStr);
 
     /*
-     * Version-String Scheme has changed since JDK 9 (See JEP223).
-     * afterJDK9 means JDK 9+ (1) or not (0)?
-     * major means hotspot version until JDK8, jdk major version since JDK 9.
-     * minor means jdk minor version.
-     * build means build version.
+     * Version-String Scheme has changed since JDK 9 (JEP223).
+     * afterJDK9 means whether this version is after JDK 9(1) or not(0).
+     * major means hotspot version until JDK 8, jdk major version since JDK 9.
+     * minor means jdk minor version in every JDK.
+     * build means build version in every JDK.
      * security means security version which has introduced since JDK 9.
      *
      * NOT support EA because the binaries do not keep public for long.
@@ -165,7 +165,6 @@ bool TJvmInfo::setHSVersion(jvmtiEnv *jvmti) {
 
       if (likely(result != 2)) {
         /* Parse version string of JDK 9 GA (Minor #1) and later */
-        printf("GA2");
         result = sscanf(versionStr, "%hhu.%hhu.%hhu+%hhu", &major, &minor,
             &security, &build);
         if (unlikely(result != 4)) {

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -144,7 +144,7 @@ bool TJvmInfo::setHSVersion(jvmtiEnv *jvmti) {
      * build means build version in every JDK.
      * security means security version which has introduced since JDK 9.
      *
-     * NOT support EA because the binaries do not keep public for long.
+     * NOT support Early Access because the binaries do not archive.
      * See also: https://bugs.openjdk.java.net/browse/JDK-8061493
      */
     unsigned char afterJDK9 = 0;

--- a/agent/src/heapstats-engines/jvmInfo.hpp
+++ b/agent/src/heapstats-engines/jvmInfo.hpp
@@ -28,10 +28,10 @@
 #include <stddef.h>
 
 /*!
- *  * \brief Make HotSpot version
- *   */
-#define MAKE_HS_VERSION(major, minor, micro, build) \
-  (((major) << 24) | ((minor) << 16) | ((micro) << 8) | (build))
+ * \brief Make HotSpot version
+ */
+#define MAKE_HS_VERSION(afterJDK9, major, minor, micro, build) \
+  (((afterJDK9) << 30) | ((major) << 24) | ((minor) << 16) | ((micro) << 8) | (build))
 
 /*!
  * \brief JVM performance header info.
@@ -310,7 +310,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR7046558(void) {
     // hs22.0-b03
-    return (this->_hsVersion >= MAKE_HS_VERSION(22, 0, 0, 3));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 22, 0, 0, 3));
   }
 
   /*!
@@ -320,7 +320,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR7017732(void) {
     // hs21.0-b06
-    return (this->_hsVersion >= MAKE_HS_VERSION(21, 0, 0, 6));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 21, 0, 0, 6));
   }
 
   /*!
@@ -332,7 +332,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR6964458(void) {
     // hs25.0-b01
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 0, 0, 1));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 0, 0, 1));
   }
 
   /*!
@@ -343,7 +343,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR8000213(void) {
     // hs25.0-b04
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 0, 0, 4));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 0, 0, 4));
   }
 
   /*!
@@ -353,7 +353,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR8027746(void) {
     // hs25.20-b02
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 20, 0, 2));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 20, 0, 2));
   }
 
   /*!
@@ -364,7 +364,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR8049421(void) {
     // hs25.40-b05
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 40, 0, 5));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 40, 0, 5));
   }
 
   /*!
@@ -373,7 +373,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR8004883(void) {
     // hs25.0-b14
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 0, 0, 14));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 0, 0, 14));
   }
 
   /*!
@@ -384,7 +384,7 @@ class TJvmInfo {
    */
   inline bool isAfterCR8003424(void) {
     // hs25.0-b46
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 0, 0, 46));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 0, 0, 46));
   }
 
   /*!
@@ -394,14 +394,14 @@ class TJvmInfo {
    */
   inline bool isAfterCR8015107(void) {
     // hs25.0-b51
-    return (this->_hsVersion >= MAKE_HS_VERSION(25, 0, 0, 51));
+    return (this->_hsVersion >= MAKE_HS_VERSION(0, 25, 0, 0, 51));
   }
 
   /*!
    * \brief Running on JDK 9 or not.
    */
   inline bool isAfterJDK9(void) {
-    return (this->_hsVersion >= MAKE_HS_VERSION(26, 0, 0, 0));
+    return (this->_hsVersion >= MAKE_HS_VERSION(1, 9, 0, 0, 0));
   }
 
   /*!

--- a/agent/src/heapstats-engines/libmain.cpp
+++ b/agent/src/heapstats-engines/libmain.cpp
@@ -552,10 +552,6 @@ jint CommonInitialization(JavaVM *vm, jvmtiEnv **jvmti, char *options) {
     return GET_LOW_LEVEL_INFO_FAILED;
   }
 
-  if (!jvmInfo->setHSVersion(*jvmti)) {
-    return GET_LOW_LEVEL_INFO_FAILED;
-  }
-
   /* Initialize configuration */
   conf = new TConfiguration(jvmInfo);
 
@@ -573,6 +569,11 @@ jint CommonInitialization(JavaVM *vm, jvmtiEnv **jvmti, char *options) {
 
   logger->setLogLevel(conf->LogLevel()->get());
   logger->setLogFile(conf->LogFile()->get());
+
+  /* Parse JDK Version */
+  if (!jvmInfo->setHSVersion(*jvmti)) {
+    return GET_LOW_LEVEL_INFO_FAILED;
+  }
 
   /* Show package information. */
   logger->printInfoMsg(PACKAGE_STRING);

--- a/agent/test/oome/OOME.java
+++ b/agent/test/oome/OOME.java
@@ -3,7 +3,7 @@ import java.util.*;
 
 public class OOME{
   public static void main(String[] args){
-    List<byte[]> list = new ArrayList<>();
+    List<byte[]> list = new ArrayList<byte[]>();
 
     while(true){
       list.add(new byte[1024*1024]);


### PR DESCRIPTION
Version-String Scheme has changed since JDK 9 (JEP223). So we need to add support for new scheme. And we remove support for Early Access because the binaries do not archive. 

See also: https://bugs.openjdk.java.net/browse/JDK-8061493
icedtea: http://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3437