### PR TITLE
Bug 3450: Remove dependency to heapstats-mbean from heapstats-plugin-api

### DIFF
--- a/analyzer/plugin-api/pom.xml
+++ b/analyzer/plugin-api/pom.xml
@@ -82,11 +82,6 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>heapstats-mbean</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>heapstats-core</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
I tried to build HeapStats Analyzer Plugin with [Plugin API](https://mvnrepository.com/artifact/jp.co.ntt.oss.heapstats/heapstats-plugin-api), but it was failed as below:

``` 
[WARNING] The POM for jp.co.ntt.oss.heapstats:heapstats-mbean:jar:2.1-m1 is missing, no dependency information available
[DEBUG] Could not find metadata jp.co.ntt.oss.heapstats:heapstats:2.1-SNAPSHOT/maven-metadata.xml in local (/home/yasuenag/.m2/repository)
 ```

I think we should remove dependency to heapstats-mbean from POM in plugin-api, and should upload new Plugin API to Maven Central.
