### PR TITLE
Bug 3456: Build warnings w/ GCC 7.2.1

### DIFF
--- a/agent/src/heapstats-engines/gcWatcher.cpp
+++ b/agent/src/heapstats-engines/gcWatcher.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file gcWatcher.cpp
  * \brief This file is used to take snapshot when finish garbage collection.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -55,6 +55,8 @@ TGCWatcher::~TGCWatcher(void) { /* Do nothing. */ }
  * \param jni   [in] JNI environment object.
  * \param data  [in] Pointer of user data.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-label"
 void JNICALL TGCWatcher::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
   /* Get self. */
   TGCWatcher *controller = (TGCWatcher *)data;
@@ -92,6 +94,7 @@ RACE_COND_DEBUG_POINT:
   /* Change running state. */
   controller->_isRunning = false;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief Make and begin Jthread.

--- a/agent/src/heapstats-engines/jvmSockCmd.cpp
+++ b/agent/src/heapstats-engines/jvmSockCmd.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file jvmSockCmd.cpp
  * \brief This file is used by thread dump.
- * Copyright (C) 2011-2015 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -305,6 +305,8 @@ int TJVMSockCmd::openJvmSock(char* path) {
  * \param pathLen [in]  Max length of param "path".
  * \return Search result.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 bool TJVMSockCmd::findJvmSock(char* path, int pathLen) {
   /* Sanity check. */
   if (unlikely(path == NULL || pathLen <= 0)) {
@@ -357,6 +359,7 @@ bool TJVMSockCmd::findJvmSock(char* path, int pathLen) {
 
   return true;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief Create attach file.
@@ -364,6 +367,8 @@ bool TJVMSockCmd::findJvmSock(char* path, int pathLen) {
  * \param pathLen [in]  Max length of param "path".
  * \return Process result.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
 bool TJVMSockCmd::createAttachFile(char* path, int pathLen) {
   /* Sanity check. */
   if (unlikely(path == NULL || pathLen <= 0)) {
@@ -425,3 +430,5 @@ bool TJVMSockCmd::createAttachFile(char* path, int pathLen) {
 
   return true;
 }
+#pragma GCC diagnostic pop
+

--- a/agent/src/heapstats-engines/snapShotProcessor.cpp
+++ b/agent/src/heapstats-engines/snapShotProcessor.cpp
@@ -57,6 +57,8 @@ TSnapShotProcessor::~TSnapShotProcessor(void) { /* Do Nothing. */ }
  * \param jni   [in] JNI environment information.
  * \param data  [in] Monitor-object for class-container.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-label"
 void JNICALL
     TSnapShotProcessor::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
   /* Ranking pointer. */
@@ -137,6 +139,7 @@ RACE_COND_DEBUG_POINT:
   /* Change running state. */
   controller->_isRunning = false;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief Start parallel work by JThread.


### PR DESCRIPTION
This PR is for [Bug 3456](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3456).

I tried to build HeapStats Agent on Fedora 26 with GCC 7.2.1, but it reported some warnings as below:


1.
```
snapShotProcessor.cpp: In static member function 'static void TSnapShotProcessor::entryPoint(jvmtiEnv*, JNIEnv*, void*)':
snapShotProcessor.cpp:83:1: warning: label 'RACE_COND_DEBUG_POINT' defined but not used [-Wunused-label]
 RACE_COND_DEBUG_POINT:
 ^~~~~~~~~~~~~~~~~~~~~
```

`RACE_COND_DEBUG_POINT` is for race condition test. So we can ignore this warning.


2.
```
gcWatcher.cpp: In static member function 'static void TGCWatcher::entryPoint(jvmtiEnv*, JNIEnv*, void*)':
gcWatcher.cpp:76:1: warning: label 'RACE_COND_DEBUG_POINT' defined but not used [-Wunused-label]
 RACE_COND_DEBUG_POINT:
 ^~~~~~~~~~~~~~~~~~~~~
```

`RACE_COND_DEBUG_POINT` is for race condition test. So we can ignore this warning.


3.
```
jvmSockCmd.cpp: In member function 'virtual bool TJVMSockCmd::findJvmSock(char*, int)':
jvmSockCmd.cpp:308:6: warning: '/.java_pid' directive output may be truncated writing 10 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
 bool TJVMSockCmd::findJvmSock(char* path, int pathLen) {
      ^~~~~~~~~~~
jvmSockCmd.cpp:337:13: note: 'snprintf' output between 12 and 4117 bytes into a destination of size 4096
     snprintf(sockPath, PATH_MAX, "%s/.java_pid%d", tempPath, selfPid);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

In Linux, max length of path is `PATH_MAX`. `snprintf()` try to build file path. So we can ignore this warning.


4.
```
jvmSockCmd.cpp: In member function 'virtual bool TJVMSockCmd::createAttachFile(char*, int)':
jvmSockCmd.cpp:367:6: warning: '/.attach_pid' directive output may be truncated writing 12 bytes into a region of size between 1 and 4096 [-Wformat-truncation=]
 bool TJVMSockCmd::createAttachFile(char* path, int pathLen) {
      ^~~~~~~~~~~
jvmSockCmd.cpp:398:13: note: 'snprintf' output between 14 and 4119 bytes into a destination of size 4096
     snprintf(attachPath, PATH_MAX, "%s/.attach_pid%d", tempPath, selfPid);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

In Linux, max length of path is `PATH_MAX`. `snprintf()` try to build file path. So we can ignore this warning.