### PR TITLE
Bug 3464: Fix launcher and attacher to use on Ubuntu

### DIFF
--- a/agent/attacher/heapstats-attacher.in
+++ b/agent/attacher/heapstats-attacher.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/bash
 
 
 #### Default values
@@ -65,8 +65,12 @@ fi
 
 # Check attacher.
 if test ! -f "$ATTACHER_PATH" ; then
-  echo "Attacher not found."
-  exit 2
+  echo "Attacher not found at $libexecdir, try to find heapstats-attacher.jar instead"
+  ATTACHER_PATH=$(find . -name "heapstats-attacher.jar" | head -n 1)
+  if test ! -f "$ATTACHER_PATH" ; then
+    echo "Attacher not found."
+    exit 2
+  fi
 fi
 
 # Check tools.jar

--- a/analyzer/cli/heapstats-cli.in
+++ b/analyzer/cli/heapstats-cli.in
@@ -1,10 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libexecdir=@libexecdir@
 
 CLI_JAR="$libexecdir/heapstats-cli.jar"
+# Check CLI.
+if test ! -f "$CLI_JAR" ; then
+  echo "CLI not found at $libexecdir, try to find heapstats-cli.jar instead"
+  CLI_JAR=$(find . -name "heapstats-cli.jar" | head -n 1)
+  if test ! -f "$CLI_JAR" ; then
+    echo "CLI not found"
+    exit 2
+  fi
+fi
 
 if test -x $JAVA_HOME/bin/java; then
   $JAVA_HOME/bin/java $JAVA_OPTS -jar $CLI_JAR $@

--- a/analyzer/fx/heapstats-analyzer.in
+++ b/analyzer/fx/heapstats-analyzer.in
@@ -1,10 +1,19 @@
-#!/bin/sh
+#!/bin/bash
 
 prefix=@prefix@
 exec_prefix=@exec_prefix@
 libexecdir=@libexecdir@
 
 ANALYZER_JAR="$libexecdir/heapstats-analyzer.jar"
+# Check Analyzer
+if test ! -f "$ANALYZER_JAR" ; then
+  echo "Analyzer not found at $libexecdir, try to find heapstats-analyzer.jar instead"
+  ANALYZER_JAR=$(find . -name "heapstats-analyzer.jar" | head -n 1)
+  if test ! -f "$ANALYZER_JAR" ; then
+    echo "Analyzer not found"
+    exit 2
+  fi
+fi
 
 if test -x $JAVA_HOME/bin/java; then
   $JAVA_HOME/bin/java $JAVA_OPTS -jar $ANALYZER_JAR $@


### PR DESCRIPTION
We should fix launcher and attacher to fix #123 
 * to specify what shell we use
 * to find JAR when the user does not use packaged heapstats

I tested to run on Ubuntu 16.04 LTS correctly.

https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3464