### PR TITLE
Bug 3458: Temp directory for ArchiveData is not removed when exiting

### DIFF
--- a/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
+++ b/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
@@ -104,7 +104,6 @@ public class ArchiveData {
                     }
                 });
             } catch (IOException e) {
-                e.printStackTrace();
                 throw new UncheckedIOException(e);
             }
         }

--- a/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
+++ b/analyzer/core/src/main/java/jp/co/ntt/oss/heapstats/container/log/ArchiveData.java
@@ -104,6 +104,7 @@ public class ArchiveData {
                     }
                 });
             } catch (IOException e) {
+                e.printStackTrace();
                 throw new UncheckedIOException(e);
             }
         }
@@ -111,8 +112,12 @@ public class ArchiveData {
 
     private static Set<PhantomRefWrapper> refSet;
 
+    private static Thread cleanerThread;
+
+    private static volatile boolean isCleanerTerminated;
+
     private static void cleaner() {
-        while (true) {
+        while (!isCleanerTerminated) {
             try {
                 PhantomRefWrapper ref = (PhantomRefWrapper) refQueue.remove();
                 ref.clean();
@@ -121,14 +126,29 @@ public class ArchiveData {
                 // Do nothing.
             }
         }
+
+        refSet.forEach(PhantomRefWrapper::clean);
+    }
+
+    public static void sendCleanerTerminateRequest() {
+        isCleanerTerminated = true;
+        cleanerThread.interrupt();
+
+        try {
+            cleanerThread.join();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     static {
         refQueue = new ReferenceQueue<>();
         refSet = Collections.synchronizedSet(new HashSet<>());
-        Thread th = new Thread(ArchiveData::cleaner, "ArchiveData cleaner");
-        th.setDaemon(true);
-        th.start();
+        cleanerThread = new Thread(ArchiveData::cleaner, "ArchiveData cleaner");
+        cleanerThread.setDaemon(true);
+        cleanerThread.start();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(ArchiveData::sendCleanerTerminateRequest));
     }
 
     /**
@@ -140,7 +160,6 @@ public class ArchiveData {
     public ArchiveData(LogData log) throws IOException{
         this(log, null);
         extractPath = Files.createTempDirectory("heapstats_archive").toFile();
-        extractPath.deleteOnExit();
         refSet.add(new PhantomRefWrapper(this));
     }
     


### PR DESCRIPTION
This PR is for [Bug 3458](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3458).

`ArchiveData` temp directory will be removed when JVM is exited via `File.deleteOnExit()`.
`File.deleteOnExit()` uses `File.delete()` in [DeleteOnExitHook](http://hg.openjdk.java.net/jdk9/dev/jdk/file/65464a307408/src/java.base/share/classes/java/io/DeleteOnExitHook.java#l81). However, it might be failed.

According to [Javadoc](https://docs.oracle.com/javase/9/docs/api/java/io/File.html#delete--), directory must be empty to be deleted. But we do not expect it because HeapStats Analyzer extracts all files in ZIP archive when it is loaded, and it will not removed.

We need to remove `ArchiveData` temp directory manually.