### PR TITLE
Bug 3491: Fix potential error when conflict between VMDeath and interval logging

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2017-11-08 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3491: Fix potential error when conflict between VMDeath and interval logging
+
 2017-11-01 Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 3458: Temp directory for ArchiveData is not removed when exiting

--- a/agent/src/heapstats-engines/logMain.cpp
+++ b/agent/src/heapstats-engines/logMain.cpp
@@ -105,6 +105,8 @@ inline bool TakeLogInfo(jvmtiEnv *jvmti, JNIEnv *env, TInvokeCause cause,
  *                   This value is always Interval.
  */
 void intervalLogProc(jvmtiEnv *jvmti, JNIEnv *env, TInvokeCause cause) {
+  TProcessMark mark(processing);
+
   /* Call collect log by interval. */
   if (unlikely(!TakeLogInfo(jvmti, env, cause,
                             (TMSecTime)getNowTimeSec(), ""))) {


### PR DESCRIPTION
HeapStats will get an error at corner case when a conflict between VMDeath (Agent_OnUnload()) and interval logging. We must fix it to finish JVM correctly.

https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3491

See also: #116 