### PR TITLE
Bug 3498: Agent cannot work on brandnew glibc

### DIFF
--- a/agent/src/heapstats-engines/vmFunctions.cpp
+++ b/agent/src/heapstats-engines/vmFunctions.cpp
@@ -188,8 +188,12 @@ bool TVMFunctions::getFunctionsFromSymbol(void) {
       sr_handler = (TSR_Handler) this->symFinder->findSymbol(
                                                         SR_HANDLER_SYMBOL_JDK6);
       if (sr_handler == NULL) {
-        logger->printWarnMsg("SR_handler() not found.");
-        return false;
+        sr_handler = (TSR_Handler) this->symFinder->findSymbol(
+                                                   SR_HANDLER_SYMBOL_FALLBACK2);
+        if (sr_handler == NULL) {
+          logger->printWarnMsg("SR_handler() not found.");
+          return false;
+        }
       }
     }
   }

--- a/agent/src/heapstats-engines/vmFunctions.hpp
+++ b/agent/src/heapstats-engines/vmFunctions.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file vmFunctions.hpp
  * \brief This file includes functions in HotSpot VM.
- * Copyright (C) 2014-2016 Yasumasa Suenaga
+ * Copyright (C) 2014-2017 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -116,9 +116,10 @@
 /*!
  * \brief Symbol of SR_handler()
  */
-#define SR_HANDLER_SYMBOL          "_ZL10SR_handleriP7siginfoP8ucontext"
-#define SR_HANDLER_SYMBOL_FALLBACK "_ZL10SR_handleriP9siginfo_tP8ucontext"
-#define SR_HANDLER_SYMBOL_JDK6     "_Z10SR_handleriP7siginfoP8ucontext"
+#define SR_HANDLER_SYMBOL           "_ZL10SR_handleriP7siginfoP8ucontext"
+#define SR_HANDLER_SYMBOL_FALLBACK  "_ZL10SR_handleriP9siginfo_tP8ucontext"
+#define SR_HANDLER_SYMBOL_JDK6      "_Z10SR_handleriP7siginfoP8ucontext"
+#define SR_HANDLER_SYMBOL_FALLBACK2 "_ZL10SR_handleriP9siginfo_tP10ucontext_t"
 
 /*!
  * \brief Symbol of ObjectSynchronizer::get_lock_owner().

--- a/agent/src/heapstats-engines/vmFunctions.hpp
+++ b/agent/src/heapstats-engines/vmFunctions.hpp
@@ -113,13 +113,27 @@
 #define USERHANDLER_SYMBOL "_ZL11UserHandleriPvS_"
 #define USERHANDLER_SYMBOL_JDK6 "_Z11UserHandleriPvS_"
 
+
 /*!
  * \brief Symbol of SR_handler()
  */
 #define SR_HANDLER_SYMBOL           "_ZL10SR_handleriP7siginfoP8ucontext"
+/* 
+ * Adapt to rename siginfo to siginfo_t
+ *   https://sourceware.org/git/?p=glibc.git;a=commit;h=87df4a4b09abdb1b1af41c9c398b86ecdedcb635
+ */
 #define SR_HANDLER_SYMBOL_FALLBACK  "_ZL10SR_handleriP9siginfo_tP8ucontext"
+/* 
+ * Adapt to old C++ compiler
+ * (Sun/Oracle JDK 6 FCS, etc)
+ */
 #define SR_HANDLER_SYMBOL_JDK6      "_Z10SR_handleriP7siginfoP8ucontext"
+/*
+ * Adapt to rename ucontext to ucontext_t
+ *   https://sourceware.org/bugzilla/show_bug.cgi?id=21457
+ */
 #define SR_HANDLER_SYMBOL_FALLBACK2 "_ZL10SR_handleriP9siginfo_tP10ucontext_t"
+
 
 /*!
  * \brief Symbol of ObjectSynchronizer::get_lock_owner().


### PR DESCRIPTION
This PR is for [Bug 3498](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3498)

HeapStats Agent cannot work on glibc 2.27 or later.

Bug 21457: sys/ucontext.h namespace
  https://sourceware.org/bugzilla/show_bug.cgi?id=21457

This glibc change has removed `ucontext` definition. So symbol of `SR_handler()` in `libjvm.so` is changed when we build on OpenJDK with brandnew glibc.

At least, I encountered this issue with OpenJDK 8 which is provided by Fedora 27 x86_64. It has glibc 2.26. According to glibc bugzilla, this change has been merged to 2.27.


Anyway, we should adapt to this change.