### PR TITLE
Bug 3515: Cannot build HeapStats Agent on CentOS 6 after merging TBB

### DIFF
--- a/agent/src/heapstats-engines/snapShotContainer.cpp
+++ b/agent/src/heapstats-engines/snapShotContainer.cpp
@@ -227,7 +227,8 @@ TChildClassCounter *TSnapShotContainer::pushNewChildClass(
   /* Set to children map. */
   TChildrenMapKey key = std::make_pair(clsCounter, objData->klassOop);
   TChildrenMap::accessor acc;
-  childrenMap.insert(acc, std::make_pair(key, newCounter));
+  TChildrenMap::value_type value = std::make_pair(key, newCounter);
+  childrenMap.insert(acc, value);
   acc.release();
 
   /* Add new counter to children list */


### PR DESCRIPTION
This PR is for [Bug 3515](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3515).

We cannot build HeapStats Agent on CentOS 6 after merging Intel TBB as following:

```
snapShotContainer.cpp: In member function ‘virtual TChildClassCounter* TSnapShotContainer::pushNewChildClass(TClassCounter*, TObjectData*)’:                                                                                               snapShotContainer.cpp:230: error: call of overloaded ‘insert(tbb::concurrent_hash_map<std::pair<TClassCounter*, void*>, TChildClassCounter*, tbb::tbb_hash_compare<std::pair<TClassCounter*, void*> >, tbb::tbb_allocator<std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*> > >::accessor&, std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*>)’ is ambiguous                                                                                              /usr/include/tbb/concurrent_hash_map.h:840: note: candidates are: bool tbb::concurrent_hash_map<Key, T, HashCompare, A>::insert(tbb::concurrent_hash_map<Key, T, HashCompare, A>::const_accessor&, const Key&) [with Key = std::pair<TClassCounter*, void*>, T = TChildClassCounter*, HashCompare = tbb::tbb_hash_compare<std::pair<TClassCounter*, void*> >, Allocator = tbb::tbb_allocator<std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*> >]

/usr/include/tbb/concurrent_hash_map.h:847: note:                 bool tbb::concurrent_hash_map<Key, T, HashCompare, A>::insert(tbb::concurrent_hash_map<Key, T, HashCompare, A>::accessor&, const Key&) [with Key = std::pair<TClassCounter*, void*>, T = TChildClassCounter*, HashCompare = tbb::tbb_hash_compare<std::pair<TClassCounter*, void*> >, Allocator = tbb::tbb_allocator<std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*> >]

/usr/include/tbb/concurrent_hash_map.h:854: note:                 bool tbb::concurrent_hash_map<Key, T, HashCompare, A>::insert(tbb::concurrent_hash_map<Key, T, HashCompare, A>::const_accessor&, const std::pair<const Key, T>&) [with Key = std::pair<TClassCounter*, void*>, T = TChildClassCounter*, HashCompare = tbb::tbb_hash_compare<std::pair<TClassCounter*, void*> >, Allocator = tbb::tbb_allocator<std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*> >]

/usr/include/tbb/concurrent_hash_map.h:861: note:                 bool tbb::concurrent_hash_map<Key, T, HashCompare, A>::insert(tbb::concurrent_hash_map<Key, T, HashCompare, A>::accessor&, const std::pair<const Key, T>&) [with Key = std::pair<TClassCounter*, void*>, T = TChildClassCounter*, HashCompare = tbb::tbb_hash_compare<std::pair<TClassCounter*, void*> >, Allocator = tbb::tbb_allocator<std::pair<std::pair<TClassCounter*, void*>, TChildClassCounter*> >]
```

We have not seen this error CentOS 7 or later, and I can reproduce this error with minumum source as below. So I guess this error causes C++ compiler.

```
#include <utility>
#include <tbb/concurrent_hash_map.h>

typedef std::pair<int, int> TKey;
typedef tbb::concurrent_hash_map<TKey, const char *> TMap;

int main(int argc, char *argv[]){
  TMap map;
  TMap::accessor acc;
  TKey key = std::make_pair(0, 1);
  
  map.insert(acc, std::make_pair(key, "aaa"));
  acc.release();

  return 0;
}
```

According to PR for merging TBB #97 , we need to support CentOS / RHEL 6 or later. So I want to fix it.