### PR TITLE
Bug 3528: Support Serial GC on JDK 10

### DIFF
--- a/agent/src/heapstats-engines/jvmInfo.hpp
+++ b/agent/src/heapstats-engines/jvmInfo.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file jvmInfo.hpp
  * \brief This file is used to get JVM performance information.
- * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -398,10 +398,17 @@ class TJvmInfo {
   }
 
   /*!
-   * \brief Running on JDK 9 or not.
+   * \brief Running on JDK 9
    */
   inline bool isAfterJDK9(void) {
     return (this->_hsVersion >= MAKE_HS_VERSION(1, 9, 0, 0, 0));
+  }
+
+  /*!
+   * \brief Running on JDK 10 or later
+   */
+  inline bool isAfterJDK10(void) {
+    return (this->_hsVersion >= MAKE_HS_VERSION(1, 10, 0, 0, 0));
   }
 
   /*!

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -3,7 +3,7 @@
  * \brief This file is used to override JVM inner function.<br>
  *        The function defined this file, used with v-table hook.<br>
  *        So in this file, all function is written by only assembler and macro.
- * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -240,6 +240,13 @@ OVERRIDE_DEFINE(par_jdk9, 2, 2)
 OVERRIDE_DEFINE(par_jdk9, 3, 2)
 /* InstanceClassLoaderKlass::oop_ms_adjust_pointers(oopDesc*) */
 OVERRIDE_DEFINE(par_jdk9, 4, 2)
+
+/* For JDK 10 Serial / Parallel GC hook */
+
+/* AdjustPointerClosure::do_oop(oopDesc**) */
+OVERRIDE_DEFINE(par_jdk10, 0, 2)
+/* AdjustPointerClosure::do_oop(unsigned int*) */
+OVERRIDE_DEFINE(par_jdk10, 1, 2)
 
 /* For JDK 9 ParallelOld GC hook */
 

--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -247,6 +247,17 @@ OVERRIDE_DEFINE(par_jdk9, 4, 2)
 OVERRIDE_DEFINE(par_jdk10, 0, 2)
 /* AdjustPointerClosure::do_oop(unsigned int*) */
 OVERRIDE_DEFINE(par_jdk10, 1, 2)
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, MarkAndPushClosure*) */
+OVERRIDE_DEFINE(par_jdk10, 2, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, MarkAndPushClosure*) */
+OVERRIDE_DEFINE(par_jdk10, 3, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, MarkAndPushClosure*) */
+OVERRIDE_DEFINE(par_jdk10, 4, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, MarkAndPushClosure*) */
+OVERRIDE_DEFINE(par_jdk10, 5, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, MarkAndPushClosure*) */
+OVERRIDE_DEFINE(par_jdk10, 6, 2)
+
 
 /* For JDK 9 ParallelOld GC hook */
 

--- a/agent/src/heapstats-engines/overrider.hpp
+++ b/agent/src/heapstats-engines/overrider.hpp
@@ -124,6 +124,15 @@ typedef enum {
   DEFINE_OVERRIDE_FUNC_N(prefix, 3)    \
   DEFINE_OVERRIDE_FUNC_N(prefix, 4)
 
+#define DEFINE_OVERRIDE_FUNC_7(prefix) \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 0)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 1)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 2)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 3)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 4)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 5)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 6)
+
 #define DEFINE_OVERRIDE_FUNC_8(prefix) \
   DEFINE_OVERRIDE_FUNC_N(prefix, 0)    \
   DEFINE_OVERRIDE_FUNC_N(prefix, 1)    \
@@ -248,7 +257,9 @@ extern "C" void callbackForParallel(void *oop);
 extern "C" void callbackForParallelWithMarkCheck(void *oop);
 extern "C" void callbackForParOld(void *oop);
 extern "C" void callbackForDoOop(void **oop);
+extern "C" void callbackForDoOopWithMarkCheck(void **oop);
 extern "C" void callbackForDoNarrowOop(unsigned int *narrowOop);
+extern "C" void callbackForDoNarrowOopWithMarkCheck(unsigned int *narrowOop);
 extern "C" void callbackForIterate(void *oop);
 extern "C" void callbackForSweep(void *oop);
 extern "C" void callbackForAdjustPtr(void *oop);

--- a/agent/src/heapstats-engines/overrider.hpp
+++ b/agent/src/heapstats-engines/overrider.hpp
@@ -1,7 +1,7 @@
 /*!
  * \file overrider.hpp
  * \brief Controller of overriding functions in HotSpot VM.
- * Copyright (C) 2014-2016 Yasumasa Suenaga
+ * Copyright (C) 2014-2018 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -176,7 +176,9 @@ typedef enum {
  * \brief Macro to select override function with CR.
  */
 #define SELECT_HOOK_FUNCS(prefix)              \
-  if (jvmInfo->isAfterJDK9()) {                \
+  if (jvmInfo->isAfterJDK10()) {               \
+    prefix##_hook = jdk10_##prefix##_hook;     \
+  } else if (jvmInfo->isAfterJDK9()) {         \
     prefix##_hook = jdk9_##prefix##_hook;      \
   } else if (jvmInfo->isAfterCR8049421()) {    \
     prefix##_hook = CR8049421_##prefix##_hook; \


### PR DESCRIPTION
This PR is for [Bug 3528](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3528).

According to [JDK-8138737](https://bugs.openjdk.java.net/browse/JDK-8138737), Serial GC hook does not work on JDK 10.
We need to hook `AdjustPointerClosure::do_oop()` in case of JDK 10.