### PR TITLE
Bug 3529: Support Parallel Full GC for G1 (JEP 307)

### DIFF
--- a/agent/src/heapstats-engines/overrideFunc.S
+++ b/agent/src/heapstats-engines/overrideFunc.S
@@ -306,6 +306,56 @@ OVERRIDE_DEFINE(g1_jdk9, 10, 2)
 /* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
 OVERRIDE_DEFINE(g1_jdk9, 11, 2)
 
+/* For JDK 10 G1 GC hook */
+
+/* initial-mark */
+/* G1ParCopyClosure<(G1Barrier)0, (G1Mark)1, false>::do_oop(oopDesc**) */
+OVERRIDE_DEFINE(g1_jdk10, 0, 2)
+/* G1ParCopyClosure<(G1Barrier)0, (G1Mark)1, false>::do_oop(unsigned int*) */
+OVERRIDE_DEFINE(g1_jdk10, 1, 2)
+
+/* concurrent-root-region-scan */
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 2, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 3, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 4, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 5, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1RootRegionScanClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 6, 2)
+
+/* concurrent-mark / remark */
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 7, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 8, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 9, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 10, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1CMOopClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 11, 2)
+
+/* Parallel Full GC Root Scan */
+/* G1MarkAndPushClosure::do_oop(oopDesc**) */
+OVERRIDE_DEFINE(g1_jdk10, 12, 2)
+/* G1MarkAndPushClosure::do_oop(unsigned int*) */
+OVERRIDE_DEFINE(g1_jdk10, 13, 2)
+
+/* Parallel Full GC oop iteration */
+/* InstanceKlass::oop_oop_iterate_nv(oopDesc*, G1MarkAndPushClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 14, 2)
+/* ObjArrayKlass::oop_oop_iterate_nv(oopDesc*, G1MarkAndPushClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 15, 2)
+/* TypeArrayKlass::oop_oop_iterate_nv(oopDesc*, G1MarkAndPushClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 16, 2)
+/* InstanceRefKlass::oop_oop_iterate_nv(oopDesc*, G1MarkAndPushClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 17, 2)
+/* InstanceClassLoaderKlass::oop_oop_iterate_nv(oopDesc*, G1MarkAndPushClosure*) */
+OVERRIDE_DEFINE(g1_jdk10, 18, 2)
+
 
 #ifdef AVOID__i686
 /* Restore definition. */

--- a/agent/src/heapstats-engines/overrider.cpp
+++ b/agent/src/heapstats-engines/overrider.cpp
@@ -85,6 +85,7 @@ DEFINE_OVERRIDE_FUNC_5(cms_new_jdk9);
 DEFINE_OVERRIDE_FUNC_9(g1);
 DEFINE_OVERRIDE_FUNC_11(g1_6964458);
 DEFINE_OVERRIDE_FUNC_12(g1_jdk9);
+DEFINE_OVERRIDE_FUNC_19(g1_jdk10);
 
 /*!
  * \brief Override function for cleanup and System.gc() event on G1GC.
@@ -743,7 +744,87 @@ THookFunctionInfo jdk9_g1_hook[] = {
         &callbackForIterate),
     HOOK_FUNC_END};
 
-#define jdk10_g1_hook jdk9_g1_hook
+/*!
+ * \brief Pointer of hook information on G1GC for after JDK 10.
+ */
+THookFunctionInfo jdk10_g1_hook[] = {
+    HOOK_FUNC(
+        g1_jdk10, 0, "_ZTV16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE",
+        "_ZN16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE6do_oopEPP7oopDesc",
+        &callbackForDoOop),
+    HOOK_FUNC(
+        g1_jdk10, 1, "_ZTV16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE",
+        "_ZN16G1ParCopyClosureIL9G1Barrier0EL6G1Mark1ELb0EE6do_oopEPj",
+        &callbackForDoNarrowOop),
+    HOOK_FUNC(
+        g1_jdk10, 2, "_ZTV13InstanceKlass",
+        "_ZN13InstanceKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 3, "_ZTV13ObjArrayKlass",
+        "_ZN13ObjArrayKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 4, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 5, "_ZTV16InstanceRefKlass",
+        "_ZN16InstanceRefKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 6, "_ZTV24InstanceClassLoaderKlass",
+        "_ZN24InstanceClassLoaderKlass18oop_oop_iterate_nvEP7oopDescP23G1RootRegionScanClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 7, "_ZTV13InstanceKlass",
+        "_ZN13InstanceKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 8, "_ZTV13ObjArrayKlass",
+        "_ZN13ObjArrayKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 9, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 10, "_ZTV16InstanceRefKlass",
+        "_ZN16InstanceRefKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 11, "_ZTV24InstanceClassLoaderKlass",
+        "_ZN24InstanceClassLoaderKlass18oop_oop_iterate_nvEP7oopDescP14G1CMOopClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 12, "_ZTV20G1MarkAndPushClosure",
+        "_ZN20G1MarkAndPushClosure6do_oopEPP7oopDesc",
+        &callbackForDoOop),
+    HOOK_FUNC(
+        g1_jdk10, 13, "_ZTV20G1MarkAndPushClosure",
+        "_ZN20G1MarkAndPushClosure6do_oopEPj",
+        &callbackForDoNarrowOop),
+    HOOK_FUNC(
+        g1_jdk10, 14, "_ZTV13InstanceKlass",
+        "_ZN13InstanceKlass18oop_oop_iterate_nvEP7oopDescP20G1MarkAndPushClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 15, "_ZTV13ObjArrayKlass",
+        "_ZN13ObjArrayKlass18oop_oop_iterate_nvEP7oopDescP20G1MarkAndPushClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 16, "_ZTV14TypeArrayKlass",
+        "_ZN14TypeArrayKlass18oop_oop_iterate_nvEP7oopDescP20G1MarkAndPushClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 17, "_ZTV16InstanceRefKlass",
+        "_ZN16InstanceRefKlass18oop_oop_iterate_nvEP7oopDescP20G1MarkAndPushClosure",
+        &callbackForIterate),
+    HOOK_FUNC(
+        g1_jdk10, 18, "_ZTV24InstanceClassLoaderKlass",
+        "_ZN24InstanceClassLoaderKlass18oop_oop_iterate_nvEP7oopDescP20G1MarkAndPushClosure",
+        &callbackForIterate),
+    HOOK_FUNC_END};
 
 /*!
  * \brief Pointer of hook information on G1GC.
@@ -1740,7 +1821,9 @@ void callbackForG1Full(void *thisptr) {
    * Disable G1 callback function:
    *  OopClosure for typeArrayKlass is called by G1 FullCollection.
    */
-  switchOverrideFunction(g1_hook, false);
+  if (!jvmInfo->isAfterJDK10()) {
+    switchOverrideFunction(g1_hook, false);
+  }
 
   /* Discard existed snapshot data */
   clearCurrentSnapShot();
@@ -1753,7 +1836,9 @@ void callbackForG1Full(void *thisptr) {
  */
 void callbackForG1FullReturn(void *thisptr) {
   /* Restore G1 callback. */
-  switchOverrideFunction(g1_hook, true);
+  if (!jvmInfo->isAfterJDK10()) {
+    switchOverrideFunction(g1_hook, true);
+  }
 
   if (likely(g1FinishCallbackFunc != NULL)) {
     /* Invoke callback. */

--- a/agent/src/heapstats-engines/overrider.hpp
+++ b/agent/src/heapstats-engines/overrider.hpp
@@ -172,6 +172,27 @@ typedef enum {
   DEFINE_OVERRIDE_FUNC_N(prefix, 10)    \
   DEFINE_OVERRIDE_FUNC_N(prefix, 11)
 
+#define DEFINE_OVERRIDE_FUNC_19(prefix) \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 0)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 1)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 2)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 3)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 4)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 5)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 6)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 7)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 8)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 9)     \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 10)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 11)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 12)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 13)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 14)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 15)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 16)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 17)    \
+  DEFINE_OVERRIDE_FUNC_N(prefix, 18)
+
 /*!
  * \brief Macro to select override function with CR.
  */


### PR DESCRIPTION
This PR is for [Bug 3529](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3529).

Full GC for G1 has been multi-threaded task by [JEP 307](http://openjdk.java.net/jeps/307). Thus current Full GC hook for G1 in HeapStats Agent does not work with JDK 10.

We need to support it.