### PR TITLE
Bug 3536: Cannot kill Java process on error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,12 +1,16 @@
+2018-03-12 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+
+	* Bug 3536: Cannot kill Java process on error
+
 2018-02-05 Yasumasa Suenaga <yasuenag@gmail.com>
 
 	* Bug 3515: Cannot build HeapStats Agent on CentOS 6 after merging TBB
 
-2017-01-25 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+2018-01-25 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
 
 	* Bug 3513: Move test cases for race-conditions to another repository
 
-2017-01-23 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
+2018-01-23 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>
 
 	* Bug 3512: Drop SSE3 instruction set supporting
 

--- a/agent/src/heapstats-engines/libmain.cpp
+++ b/agent/src/heapstats-engines/libmain.cpp
@@ -427,10 +427,6 @@ void JNICALL OnVMDeath(jvmtiEnv *jvmti, JNIEnv *env) {
  * \warning This function is always no return.
  */
 void forcedAbortJVM(jvmtiEnv *jvmti, JNIEnv *env, const char *causeMsg) {
-  /* Terminate all event and thread. */
-  OnVMDeath(jvmti, env);
-  logger->flush();
-
   /* Output last message. */
   logger->printCritMsg("Aborting JVM by HeapStats. cause: %s", causeMsg);
   logger->flush();


### PR DESCRIPTION
HeapStats agent forces to kill attached jvm process on error, i.e., ResourceExhausted and DeadLock, if user sets kill_on_error as true. However, HeapStats agent hangs on error because forcedAbortJVM join infinite loop to wait "processing" which is never released as the following backtrace.

**backtrace from coredump by SIGABRT**
```
Thread 11 (Thread 0x7f7e9c2aa700 (LWP 1241)):
#0  0x00007f7e9b565767 in sched_yield () from /lib64/libc.so.6
#1  0x00007f7e98d45195 in onVMDeathForLog (jvmti=jvmti@entry=0x7f7e940088a0, env=env@entry=0x7f7e94065988) at logMain.cpp:394
#2  0x00007f7e98d30c8c in OnVMDeath (jvmti=jvmti@entry=0x7f7e940088a0, env=env@entry=0x7f7e94065988) at libmain.cpp:417
#3  0x00007f7e98d3158c in forcedAbortJVM (jvmti=jvmti@entry=0x7f7e940088a0, env=env@entry=0x7f7e94065988,
    causeMsg=causeMsg@entry=0x7f7e98e273eb "resource exhausted") at libmain.cpp:431
#4  0x00007f7e98d44a13 in OnResourceExhausted (jvmti=0x7f7e940088a0, env=0x7f7e94065988, flags=<optimized out>, reserved=<optimized out>,
    description=0x7f7e9afad35b "Java heap space") at logMain.cpp:259
#5  0x00007f7e9ab8cb32 in JvmtiExport::post_resource_exhausted (resource_exhausted_flags=resource_exhausted_flags@entry=3,
    description=description@entry=0x7f7e9afad35b "Java heap space")
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/prims/jvmtiExport.cpp:1107
#6  0x00007f7e9af3a351 in CollectedHeap::common_mem_allocate_noinit (__the_thread__=0x7f7e94065730, size=<optimized out>, klass=...)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/gc_interface/collectedHeap.inline.hpp:154
#7  CollectedHeap::common_mem_allocate_init (__the_thread__=0x7f7e94065730, size=<optimized out>, klass=...)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/gc_interface/collectedHeap.inline.hpp:175
#8  CollectedHeap::array_allocate (__the_thread__=0x7f7e94065730, length=1048576, size=<optimized out>, klass=...)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/gc_interface/collectedHeap.inline.hpp:218
#9  TypeArrayKlass::allocate_common (this=0x100000768, length=1048576, length@entry=-1811523792, do_zero=do_zero@entry=true,
    __the_thread__=__the_thread__@entry=0x7f7e94065730)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/oops/typeArrayKlass.cpp:107
#10 0x00007f7e9ad202d0 in TypeArrayKlass::allocate (__the_thread__=__the_thread__@entry=0x7f7e94065730, length=length@entry=-1811523792,
    this=<optimized out>) at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/oops/typeArrayKlass.hpp:67
#11 oopFactory::new_typeArray (type=<optimized out>, length=<optimized out>, __the_thread__=__the_thread__@entry=0x7f7e94065730)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/memory/oopFactory.cpp:57
#12 0x00007f7e9aaad1b7 in InterpreterRuntime::newarray (thread=0x7f7e94065730, type=<optimized out>, size=<optimized out>)
    at /usr/src/debug/java-1.8.0-openjdk-1.8.0.161-5.b14.fc27.x86_64/openjdk/hotspot/src/share/vm/interpreter/interpreterRuntime.cpp:183
#13 0x00007f7e84418475 in ?? ()
#14 0x00007f7e84418433 in ?? ()
#15 0x00000000f61b1638 in ?? ()
#16 0x00007f7e9c2a9970 in ?? ()
#17 0x00007f7e83c34273 in ?? ()
#18 0x00007f7e9c2a99c8 in ?? ()
#19 0x00007f7e83c342f8 in ?? ()
#20 0x0000000000000000 in ?? ()
```

I tested to occur ResourceExhausted and Deadlock by agent/test/{oome,deadlock}

**oome**
<details>

```
heapstats CRIT: ALERT(RESOURCE): resource was exhausted. info:"Java heap space"
heapstats WARN: Couldn't open copy source file. cause: Permission denied
heapstats WARN: Could not copy /var/log/messages cause: Permission denied
heapstats WARN: Could not copy file: /proc/self/fd/1 cause: Invalid argument
heapstats WARN: Could not copy file: /proc/self/fd/2 cause: Invalid argument
  adding: envInfo.txt (deflated 68%)
  adding: redhat-release (stored 0%)
  adding: smaps (deflated 95%)
  adding: limits (deflated 78%)
  adding: cmdline (deflated 11%)
  adding: status (deflated 66%)
  adding: tcp (deflated 65%)
  adding: tcp6 (deflated 73%)
  adding: udp (deflated 62%)
  adding: udp6 (deflated 66%)
  adding: journalctl_-q_--all_--this-boot_--no-pager_-o_verbose.log (deflated 85%)
  adding: threaddump.txt (deflated 75%)
  adding: sockowner (stored 0%)
heapstats INFO: Collecting log has been completed: /home/ykubota/test/agent/test/oome/heapstats_analyze180312202530.zip
heapstats INFO: Elapsed Time (in Take LogInfo): 0.030000 sec (user = 0.000000, sys = 0.000000)
heapstats CRIT: Aborting JVM by HeapStats. cause: resource exhausted
```

</details>

**deadlock**
<details>

```
heapstats CRIT: ALERT(DEADLOCK): Deadlock occurred! count: 11, thread: "Thread-10"
heapstats WARN: Couldn't open copy source file. cause: Permission denied
heapstats WARN: Could not copy /var/log/messages cause: Permission denied
  adding: envInfo.txt (deflated 68%)
  adding: redhat-release (stored 0%)
  adding: smaps (deflated 96%)
  adding: limits (deflated 78%)
  adding: cmdline (deflated 17%)
  adding: status (deflated 66%)
  adding: tcp (deflated 65%)
  adding: tcp6 (deflated 73%)
  adding: udp (deflated 61%)
  adding: udp6 (deflated 66%)
  adding: journalctl_-q_--all_--this-boot_--no-pager_-o_verbose.log (deflated 85%)
  adding: fd1 (deflated 62%)
  adding: threaddump.txt (deflated 84%)
  adding: sockowner (stored 0%)
heapstats CRIT: Aborting JVM by HeapStats. cause: deadlock occurred
heapstats INFO: Collecting log has been completed: /home/ykubota/test/agent/test/deadlock/heapstats_analyze180312202752.zip
```

</details>