### PR TITLE
Bug 3571: Build process of HeapStats attacher should regard the value detected by configure

### DIFF
--- a/agent/attacher/Makefile.am
+++ b/agent/attacher/Makefile.am
@@ -7,7 +7,7 @@ all:
 	env JAVA_HOME=$(JDK_HOME) bash -c $(ANT)
 
 clean-local:
-	$(ANT) clean
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) clean"
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)/$(bindir)

--- a/agent/attacher/Makefile.in
+++ b/agent/attacher/Makefile.in
@@ -429,7 +429,7 @@ all:
 	env JAVA_HOME=$(JDK_HOME) bash -c $(ANT)
 
 clean-local:
-	$(ANT) clean
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) clean"
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)/$(bindir)

--- a/agent/src/iotracer/Makefile.am
+++ b/agent/src/iotracer/Makefile.am
@@ -1,8 +1,10 @@
+JDK_HOME = @JDK_DIR@
+
 all:
-	$(ANT) all
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) all"
  
 clean-local:
-	$(ANT) clean
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) clean"
  
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)/$(sysconfdir)/iotracer

--- a/agent/src/iotracer/Makefile.in
+++ b/agent/src/iotracer/Makefile.in
@@ -234,6 +234,7 @@ target_alias = @target_alias@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+JDK_HOME = @JDK_DIR@
 all: all-am
 
 .SUFFIXES:
@@ -419,11 +420,12 @@ uninstall-am: uninstall-local
 
 .PRECIOUS: Makefile
 
+
 all:
-	$(ANT) all
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) all"
 
 clean-local:
-	$(ANT) clean
+	env JAVA_HOME=$(JDK_HOME) bash -c "$(ANT) clean"
 
 install-exec-local:
 	$(mkdir_p) $(DESTDIR)/$(sysconfdir)/iotracer


### PR DESCRIPTION
This PR is for [Bug 3571](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3571)

Build process of HeapStats uses `$JAVA_HOME` which is detected by `configure`. `configure` will set it from `$JAVA_HOME` environment variable or `--with-jdk` configure option. It uses in build process of HeapStats Analyzer and MBean module, but agent attacher is not use it.

Build process of HeapStats attacher should also regard `$JAVA_HOME` which is detected by `configure`.