### PR TITLE
Bug 3586: Build warnings from GCC 8

### DIFF
--- a/agent/src/arch/x86/heapstats_md_x86.cpp
+++ b/agent/src/arch/x86/heapstats_md_x86.cpp
@@ -2,7 +2,7 @@
  * \file heapstats_md_x86.cpp
  * \brief Proxy library for HeapStats backend.
  *        This file implements x86 specific code for loading backend library.
- * Copyright (C) 2014 Yasumasa Suenaga
+ * Copyright (C) 2014-2018 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -112,10 +112,15 @@ void *loadHeapStatsEngine(void) {
     return NULL;
   }
 
-  sprintf(engine_path,
-          "%s/heapstats-engines/libheapstats-engine-%s-" HEAPSTATS_MAJOR_VERSION
-          ".so",
-          heapstats_path, checkInstructionSet());
+  int ret = snprintf(engine_path, PATH_MAX,
+                     "%s/heapstats-engines/libheapstats-engine-%s-"
+                     HEAPSTATS_MAJOR_VERSION ".so",
+                     heapstats_path, checkInstructionSet());
+  if (ret >= PATH_MAX) {
+    fprintf(stderr,
+            "HeapStats engine could not be loaded: engine path is too long\n");
+    return NULL;
+  }
 
   void *hEngine = dlopen(engine_path, RTLD_NOW);
   if (hEngine == NULL) {

--- a/agent/src/heapstats-engines/jvmSockCmd.cpp
+++ b/agent/src/heapstats-engines/jvmSockCmd.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file jvmSockCmd.cpp
  * \brief This file is used by thread dump.
- * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -216,7 +216,7 @@ int TJVMSockCmd::execute(char const* cmd, const TJVMSockCmdArgs conf,
  */
 bool TJVMSockCmd::createJvmSock(void) {
   /* Socket file path. */
-  char sockPath[PATH_MAX + 1] = {0};
+  char sockPath[PATH_MAX] = {0};
 
   /* Search jvm socket file. */
   if (!findJvmSock((char*)&sockPath, PATH_MAX)) {


### PR DESCRIPTION
This PR is for [Bug 3586](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3586).

I tried to build HeapStats with GCC 8 on Fedora 28, I saw few compiler warnings as below:

```
logManager.cpp: In member function 'virtual char* TLogManager::createArchiveName(TMSecTime)':
logManager.cpp:1457:31: warning: '%s' directive output may be truncated writing up to 19 bytes into a region of size between 0 and 4096 [-Wformat-truncation=]
   snprintf(arcName, PATH_MAX, "%s%s%s", namePart, time_str, extPart);
                               ^~~~~~~~            ~~~~~~~~
logManager.cpp:1457:11: note: 'snprintf' output between 1 and 8212 bytes into a destination of size 4096
   snprintf(arcName, PATH_MAX, "%s%s%s", namePart, time_str, extPart);
   ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
fsUtil.cpp: In function 'char* createUniquePath(char*, bool)':
fsUtil.cpp:422:34: warning: '_' directive output may be truncated writing 1 byte into a region of size between 0 and 4096 [-Wformat-truncation=]
     snprintf(tempPath, PATH_MAX, "%s_%06lu%s", tempName, loopCount, ext);
                                  ^~~~~~~~~~~~
fsUtil.cpp:422:34: note: directive argument in the range [0, 1000001]
fsUtil.cpp:422:13: note: 'snprintf' output between 8 and 8201 bytes into a destination of size 4096
     snprintf(tempPath, PATH_MAX, "%s_%06lu%s", tempName, loopCount, ext);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
fsUtil.cpp:438:34: warning: '_' directive output may be truncated writing 1 byte into a region of size between 0 and 4096 [-Wformat-truncation=]
     snprintf(tempPath, PATH_MAX, "%s_%6s%s", tempName, randStr, ext);
                                  ^~~~~~~~~~
fsUtil.cpp:438:13: note: 'snprintf' output between 8 and 8200 bytes into a destination of size 4096
     snprintf(tempPath, PATH_MAX, "%s_%6s%s", tempName, randStr, ext);
     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
jvmSockCmd.cpp: In member function 'virtual bool TJVMSockCmd::createJvmSock()':
jvmSockCmd.cpp:259:10: warning: 'char* strncpy(char*, const char*, size_t)' output may be truncated copying 4096 bytes from a string of length 4096 [-Wstringop-truncation]
   strncpy(socketPath, sockPath, PATH_MAX);
   ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

```
arch/x86/heapstats_md_x86.cpp: In function 'void* loadHeapStatsEngine()':
arch/x86/heapstats_md_x86.cpp:116:11: warning: '/heapstats-engines/libheapst...' directive writing 39 bytes into a region of size between 1 and 4096 [-Wformat-overflow=]
           "%s/heapstats-engines/libheapstats-engine-%s-" HEAPSTATS_MAJOR_VERSION
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           ".so",
           ~~~~~
arch/x86/heapstats_md_x86.cpp:115:10: note: 'sprintf' output between 50 and 4146 bytes into a destination of size 4096
   sprintf(engine_path,
   ~~~~~~~^~~~~~~~~~~~~
           "%s/heapstats-engines/libheapstats-engine-%s-" HEAPSTATS_MAJOR_VERSION
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           ".so",
           ~~~~~~
           heapstats_path, checkInstructionSet());
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

I want to resolve them.