### PR TITLE
Bug 3747: Add note to avoid misrecognized about ResourceExhausted

### DIFF
--- a/agent/heapstats.conf.in
+++ b/agent/heapstats.conf.in
@@ -21,6 +21,9 @@ trigger_on_dump=true
 check_deadlock=false
 
 # Trigger logging setting
+## Note: trigger_on_logerror does *NOT* work when target
+## JVM process enables {Exit|Crash}OnOutOfMemoryError
+## http://mail.openjdk.java.net/pipermail/hotspot-gc-dev/2019-July/026547.html
 trigger_on_logerror=true
 trigger_on_logsignal=true
 trigger_on_loglock=true


### PR DESCRIPTION
We believed ResourceExhausted JVM TI event handler is certain to be called even if enables {Exit|Crash}OutOfMemoryError. However, this behavior is not wroten in JVM TI spec and current implementation of HotSpot doesn't call ResourceExhausted if target JVM process enabled {Exit|Crash}OOME. 

OpenJDK folks triaged this issue as not-bug[1]. So we should leave a note for attention.
[1]: http://mail.openjdk.java.net/pipermail/hotspot-gc-dev/2019-July/026547.html