### PR TITLE
Bug 3754: Could not bundle heapstats-cli launcher

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -24,8 +24,6 @@ agent/heapstats.conf
 autom4te.cache/
 agent/attacher/dist/*.jar
 agent/attacher/heapstats-attacher
-analyzer/cli/heapstats-cli
-analyzer/fx/heapstats-analyzer
 *.o
 *.lo
 *.Po

--- a/analyzer/cli/heapstats-cli
+++ b/analyzer/cli/heapstats-cli
@@ -1,0 +1,3 @@
+#!/bin/sh
+DIR=`dirname $0`
+$DIR/java --module-path $DIR/../mods -m heapstats.cli/jp.co.ntt.oss.heapstats.cli.CliMain $@

--- a/analyzer/cli/pom.xml
+++ b/analyzer/cli/pom.xml
@@ -257,6 +257,7 @@
             <properties>
                 <package.os.name>linux</package.os.name>
                 <jlink.argument>--strip-native-debug-symbols=exclude-debuginfo-files</jlink.argument>
+                <launcher.ext/>
             </properties>
         </profile>
         <profile>
@@ -269,6 +270,7 @@
             <properties>
                 <package.os.name>windows</package.os.name>
                 <jlink.argument/>
+                <launcher.ext>.bat</launcher.ext>
             </properties>
         </profile>
         <profile>

--- a/analyzer/cli/src/main/assembly/distribution.xml
+++ b/analyzer/cli/src/main/assembly/distribution.xml
@@ -20,8 +20,7 @@
             <directory>${pom.basedir}</directory>
             <outputDirectory>${file.separator}bin</outputDirectory>
             <includes>
-                <include>heapstats-cli</include>
-                <include>heapstats-cli.bat</include>
+                <include>heapstats-cli${launcher.ext}</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/analyzer/fx/pom.xml
+++ b/analyzer/fx/pom.xml
@@ -291,6 +291,7 @@
             <properties>
                 <package.os.name>linux</package.os.name>
                 <jlink.argument>--strip-native-debug-symbols=exclude-debuginfo-files</jlink.argument>
+                <launcher.ext/>
             </properties>
         </profile>
         <profile>
@@ -303,6 +304,7 @@
             <properties>
                 <package.os.name>windows</package.os.name>
                 <jlink.argument/>
+                <launcher.ext>.bat</launcher.ext>
             </properties>
         </profile>
         <profile>

--- a/analyzer/fx/src/main/assembly/distribution.xml
+++ b/analyzer/fx/src/main/assembly/distribution.xml
@@ -39,8 +39,7 @@
             <directory>${pom.basedir}</directory>
             <outputDirectory>${file.separator}bin</outputDirectory>
             <includes>
-                <include>heapstats-analyzer</include>
-                <include>heapstats-analyzer.bat</include>
+                <include>heapstats-analyzer${launcher.ext}</include>
             </includes>
         </fileSet>
         <fileSet>


### PR DESCRIPTION
This PR is for [Bug 3754](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3754).

After [Bug 3752](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3752) (PR #144 ), HeapStats Analyzer and CLI are generated by `jlink`, but `heapstats-cli` which is launcher script of HeapStats CLI for Linux is not bundled.

Also I will refactor pom.xml to bundle launcher script correctly - now it is bundled both for Windows and for Linux in case of HeapStats Analyzer.




NOTE:  
Some depending modules (java-activation and jgraphx AFAICS) uses automatic module. Thus we cannot use `--launcher` option in `jlink`.  
If they do not use automatic module in the future, we can use `--launcher`.