### PR TITLE
Bug 3757: Update SPEC for modularity

### DIFF
--- a/specs/heapstats.spec
+++ b/specs/heapstats.spec
@@ -12,11 +12,6 @@ Source: heapstats-%{version}.tar.gz
 #Patch0: none
 Buildroot: /var/tmp/heapstats
 
-# Check OpenJFX supported platform
-%if %{?fedora:%{fedora}}%{!?fedora:0} >= 26
-%define WITH_ANALYZER 1
-%endif
-
 # Requires for running
 Requires: pcre >= 6
 Requires: tbb
@@ -31,37 +26,9 @@ BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: tbb-devel
 
-%if 0%{?WITH_ANALYZER:1}
-BuildRequires: java-1.8.0-openjdk-openjfx-devel
-%endif
-
-%package cli
-Summary:   HeapStats CLI
-Group:     Development/Tools
-BuildArch: noarch
-
-%if 0%{?WITH_ANALYZER:1}
-%package analyzer
-Summary:   HeapStats Analyzer
-Group:     Development/Tools
-BuildArch: noarch
-Requires: java-1.8.0-openjdk-openjfx
-Requires: heapstats-cli
-%endif
-
 %description
 A lightweight monitoring JVMTI agent for Java HotSpot VM.
-Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation.
-
-%description cli
-Commandline analysis tool for HeapStats.
-Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation.
-
-%if 0%{?WITH_ANALYZER:1}
-%description analyzer
-HeapStats GUI Analyzer
-Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation.
-%endif
+Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation.
 
 %prep
 %setup -q -n heapstats-2.2
@@ -82,12 +49,7 @@ CXXFLAGS="$RPM_OPT_FLAGS" ./configure \
   --without-gcov \
   --disable-profile 
 
-%if 0%{?WITH_ANALYZER:1}
-  make
-%else
-  make agent mbean RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
-  mvn -am -pl analyzer/cli package
-%endif
+make agent mbean RPM_OPT_FLAGS="$RPM_OPT_FLAGS"
 
 %install
 rm -rf $RPM_BUILD_ROOT
@@ -97,24 +59,12 @@ echo "%{_libdir}/heapstats" \
 mkdir -p $RPM_BUILD_ROOT/usr/share/snmp/mibs/
 cp ./agent/mib/HeapStatsMibs.txt $RPM_BUILD_ROOT/usr/share/snmp/mibs/
 
-%if 0%{?WITH_ANALYZER:1}
-  make install DESTDIR=${RPM_BUILD_ROOT}
-%else
-  mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/heapstats
-  cd agent
-  make install DESTDIR=${RPM_BUILD_ROOT}
-  cd ../mbean
-  make install DESTDIR=${RPM_BUILD_ROOT}
-  cd ../
-
-  # We do not privide FX analyzer.
-  # So we install CLI analyzer manually.
-  mkdir -p ${RPM_BUILD_ROOT}/%{_libexecdir}/heapstats
-  cp -fR ./analyzer/cli/target/heapstats-cli-*-bin/heapstats-cli-*/* \
-                                    ${RPM_BUILD_ROOT}%{_libexecdir}/heapstats/
-  cp -f ./analyzer/cli/heapstats-cli ${RPM_BUILD_ROOT}%{_bindir}
-  chmod a+x ${RPM_BUILD_ROOT}%{_bindir}/heapstats-cli
-%endif
+mkdir -p ${RPM_BUILD_ROOT}%{_libdir}/heapstats
+cd agent
+make install DESTDIR=${RPM_BUILD_ROOT}
+cd ../mbean
+make install DESTDIR=${RPM_BUILD_ROOT}
+cd ../
 
 %post
 /sbin/ldconfig
@@ -147,27 +97,9 @@ rm -rf $RPM_BUILD_ROOT
 /etc/ld.so.conf.d/heapstats-agent.conf
 /usr/share/snmp/mibs/HeapStatsMibs.txt
 
-%files cli
-/usr/bin/heapstats-cli
-%dir %{_libexecdir}/heapstats/
-%{_libexecdir}/heapstats/heapstats-cli.jar
-%dir %{_libexecdir}/heapstats/lib/
-%{_libexecdir}/heapstats/lib/heapstats-core.jar
-%{_libexecdir}/heapstats/lib/heapstats-mbean.jar
-%{_libexecdir}/heapstats/lib/heapstats-jmx-helper.jar
-
-%if 0%{?WITH_ANALYZER:1}
-%files analyzer
-/usr/bin/heapstats-analyzer
-%{_libexecdir}/heapstats/heapstats-analyzer.jar
-%{_libexecdir}/heapstats/THIRD_PARTY_README
-%{_libexecdir}/heapstats/filterDefine.xsd
-%{_libexecdir}/heapstats/heapstats.properties
-%{_libexecdir}/heapstats/lib/jgraphx.jar
-%{_libexecdir}/heapstats/lib/heapstats-plugin-api.jar
-%endif
-
 %changelog
+* Sun Oct 06 2019 Yasumasa Suenaga <yasuenag@gmail.com>
+- Update SPEC for modularity
 * Wed Apr 04 2018 Yasumasa Suenaga <yasuenag@gmail.com>
 - Update version number to 2.2.trunk
 * Tue Jan 23 2018 KUBOTA Yuji <kubota.yuji@lab.ntt.co.jp>


### PR DESCRIPTION
This PR is for [Bug 3757](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3757).

HeapStats has been modularized since [Bug 3752](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3752). This ticket migrates HeapStats Analyzer and CLI to jlink'ed app.

Currently HeapStats ships RPMs for Analyzer and CLI which provide JARs and configuration files. But we need to provide also Java runtime since then!

Thus I want to exclude Analyzer and CLI from SPEC and want to ship them as ZIP archive like the past.  
ZIP archive can be built on `heapstats/builder:prep-2.2` container in [HeapStats Builder](https://cloud.docker.com/u/heapstats/repository/docker/heapstats/builder).