### PR TITLE
Bug 3759: HeapStats Agent could not be built on CentOS 6

### DIFF
--- a/agent/src/heapstats-engines/fsUtil.cpp
+++ b/agent/src/heapstats-engines/fsUtil.cpp
@@ -350,6 +350,8 @@ void removeTempDir(char const *basePath) {
  * \param isDirectory [in] Path is directory.
  * \return Unique path.<br>Don't forget deallocate.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 char *createUniquePath(char *path, bool isDirectory) {
   /* Variable for temporary path. */
   char tempPath[PATH_MAX] = {0};
@@ -369,8 +371,6 @@ char *createUniquePath(char *path, bool isDirectory) {
   /* Search extension. */
   char *extPos = strrchr(path, '.');
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
   /* If create path for file and exists extension. */
   if (!isDirectory && extPos != NULL) {
     int pathSize = (extPos - path);
@@ -386,7 +386,6 @@ char *createUniquePath(char *path, bool isDirectory) {
 
   /* Copy default path. */
   strncpy(tempPath, path, PATH_MAX);
-#pragma GCC diagnostic pop
 
   /* Try make unique path loop. */
   const unsigned long int MAX_RETRY_COUNT = 1000000;
@@ -460,6 +459,7 @@ char *createUniquePath(char *path, bool isDirectory) {
 
   return result;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief Get parent directory path.

--- a/agent/src/heapstats-engines/logManager.cpp
+++ b/agent/src/heapstats-engines/logManager.cpp
@@ -1428,6 +1428,8 @@ int TLogManager::makeSocketOwnerFile(char const *basePath) {
  *         Don't forget deallocate memory.<br>
  *         Process is failure, if value is null.
  */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
 char *TLogManager::createArchiveName(TMSecTime nowTime) {
   time_t nowTimeSec = 0;
   struct tm time_struct = {0};
@@ -1436,8 +1438,6 @@ char *TLogManager::createArchiveName(TMSecTime nowTime) {
   char extPart[PATH_MAX] = {0};
   char namePart[PATH_MAX] = {0};
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-truncation"
   /* Search extension. */
   char *archiveFileName = conf->ArchiveFile()->get();
   char *extPos = strrchr(archiveFileName, '.');
@@ -1449,7 +1449,6 @@ char *TLogManager::createArchiveName(TMSecTime nowTime) {
     /* Not found extension in path. */
     strncpy(namePart, archiveFileName, PATH_MAX);
   }
-#pragma GCC diagnostic pop
 
   /* Get now datetime and convert to string. */
   nowTimeSec = (time_t)(nowTime / 1000);
@@ -1466,3 +1465,4 @@ char *TLogManager::createArchiveName(TMSecTime nowTime) {
   /* Create unique file name. */
   return createUniquePath(arcName, false);
 }
+#pragma GCC diagnostic pop


### PR DESCRIPTION
This PR is for [Bug 3759](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3759).

I tried to build HeapStats Agent on CentOS 6, but I encountered error messages as below:

```
logManager.cpp: In member function 'virtual char* TLogManager::createArchiveName(TMSecTime)':
logManager.cpp:1439: error: #pragma GCC diagnostic not allowed inside functions
logManager.cpp:1440: error: #pragma GCC diagnostic not allowed inside functions
logManager.cpp:1452: error: #pragma GCC diagnostic not allowed inside functions
make[3]: *** [libheapstats_engine_none_2_2_so-logManager.o] Error 1
```

This issue appears in trunk only. Also I did not see them on CentOS 7 or later.  
We need to move `#pragma` from the inside function for old compiler.