### PR TITLE
Bug 3765: pthread mutex lock/unlock enhancement

### DIFF
--- a/agent/src/heapstats-engines/deadlockDetector.cpp
+++ b/agent/src/heapstats-engines/deadlockDetector.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file deadlockDetector.cpp
  * \brief This file is used by find deadlock.
- * Copyright (C) 2017 Yasumasa Suenaga
+ * Copyright (C) 2017-2019 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -181,8 +181,9 @@ namespace dldetector {
     jvmti->GetObjectHashCode(thread, &thread_hash);
     jvmti->GetObjectHashCode(object, &monitor_hash);
 
-    ENTER_PTHREAD_SECTION(&mutex);
     {
+      TMutexLocker locker(&mutex);
+
       /* Avoid JDK-8185164 */
       bool canSkip = true;
 
@@ -233,7 +234,6 @@ namespace dldetector {
         }
       }
     }
-    EXIT_PTHREAD_SECTION(&mutex);
   }
 
 
@@ -262,8 +262,9 @@ namespace dldetector {
       return;
     }
 
-    ENTER_PTHREAD_SECTION(&mutex);
     {
+      TMutexLocker locker(&mutex);
+
       /* Remove all owned monitors from owner list */
       for (int idx = 0; idx < monitor_cnt; idx++) {
         jint monitor_hash;
@@ -277,7 +278,6 @@ namespace dldetector {
       jvmti->GetObjectHashCode(thread, &thread_hash);
       waiter_list.erase(thread_hash);
     }
-    EXIT_PTHREAD_SECTION(&mutex);
   }
 
 
@@ -343,12 +343,11 @@ namespace dldetector {
       sched_yield();
     }
 
-    ENTER_PTHREAD_SECTION(&mutex);
     {
+      TMutexLocker locker(&mutex);
       monitor_owners.clear();
       waiter_list.clear();
     }
-    EXIT_PTHREAD_SECTION(&mutex);
   }
 
 }

--- a/agent/src/heapstats-engines/fsUtil.cpp
+++ b/agent/src/heapstats-engines/fsUtil.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file fsUtil.cpp
  * \brief This file is utilities to access file system.
- * Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -242,8 +242,8 @@ int createTempDir(char **basePath, char const *wishesName) {
   }
 
   int raisedErrNum = -1;
-  /* Get mutex. */
-  ENTER_PTHREAD_SECTION(&directoryMutex) {
+  {
+    TMutexLocker locker(&directoryMutex);
 
     /* Create unique directory path. */
     uniqName = createUniquePath((char *)wishesName, true);
@@ -258,8 +258,6 @@ int createTempDir(char **basePath, char const *wishesName) {
       }
     }
   }
-  /* Release mutex. */
-  EXIT_PTHREAD_SECTION(&directoryMutex)
 
   /* If failed to create temporary directory. */
   if (unlikely(raisedErrNum != 0)) {
@@ -330,8 +328,8 @@ void removeTempDir(char const *basePath) {
   /* Cleanup. */
   closedir(dir);
 
-  /* Get mutex. */
-  ENTER_PTHREAD_SECTION(&directoryMutex) {
+  {
+    TMutexLocker locker(&directoryMutex);
 
     /* Remove directory. */
     if (unlikely(rmdir(basePath) != 0)) {
@@ -340,8 +338,6 @@ void removeTempDir(char const *basePath) {
     }
 
   }
-  /* Release mutex. */
-  EXIT_PTHREAD_SECTION(&directoryMutex)
 }
 
 /*!

--- a/agent/src/heapstats-engines/gcWatcher.cpp
+++ b/agent/src/heapstats-engines/gcWatcher.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file gcWatcher.cpp
  * \brief This file is used to take snapshot when finish garbage collection.
- * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -68,7 +68,9 @@ void JNICALL TGCWatcher::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
     /* Variable for notification flag. */
     bool needProcess = false;
 
-    ENTER_PTHREAD_SECTION(&controller->mutex) {
+    {
+      TMutexLocker locker(&controller->mutex);
+
       /* If no exists request. */
       if (likely(controller->_numRequests == 0)) {
         /* Wait for notification or termination. */
@@ -82,7 +84,6 @@ RACE_COND_DEBUG_POINT:
         needProcess = true;
       }
     }
-    EXIT_PTHREAD_SECTION(&controller->mutex)
 
     /* If waiting finished by notification. */
     if (needProcess) {

--- a/agent/src/heapstats-engines/logMain.cpp
+++ b/agent/src/heapstats-engines/logMain.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file logmain.cpp
  * \brief This file is used common logging process.
- * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -226,8 +226,8 @@ void JNICALL OnResourceExhausted(jvmtiEnv *jvmti, JNIEnv *env, jint flags,
   }
 
   bool isCollectLog = true;
-  /* Lock to use in multi-thread. */
-  ENTER_PTHREAD_SECTION(&errMutex) {
+  {
+    TMutexLocker locker(&errMutex);
 
     /* If collected already and collect first only. */
     if (conf->FirstCollect()->get() && conf->isFirstCollected()) {
@@ -238,8 +238,6 @@ void JNICALL OnResourceExhausted(jvmtiEnv *jvmti, JNIEnv *env, jint flags,
     conf->setFirstCollected(true);
 
   }
-  /* Unlock to use in multi-thread. */
-  EXIT_PTHREAD_SECTION(&errMutex)
 
   if (isCollectLog) {
     /* Setting collect log cause. */

--- a/agent/src/heapstats-engines/logManager.cpp
+++ b/agent/src/heapstats-engines/logManager.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file logManager.cpp
  * \brief This file is used collect log information.
- * Copyright (C) 2011-2018 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -255,8 +255,8 @@ int TLogManager::collectNormalLog(TInvokeCause cause, TMSecTime nowTime,
            /* Params : Archive file name. */
            archivePath);
 
-  /* Get mutex. */
-  ENTER_PTHREAD_SECTION(&logMutex) {
+  {
+    TMutexLocker locker(&logMutex);
 
     /* Open log file. */
     int fd = open(conf->HeapLogFile()->get(), O_CREAT | O_WRONLY | O_APPEND,
@@ -282,8 +282,7 @@ int TLogManager::collectNormalLog(TInvokeCause cause, TMSecTime nowTime,
       }
     }
   }
-  /* Release mutex. */
-  EXIT_PTHREAD_SECTION(&logMutex)
+
   return result;
 }
 
@@ -379,8 +378,8 @@ int TLogManager::collectAllLog(jvmtiEnv *jvmti, JNIEnv *env, TInvokeCause cause,
      */
     result = -1;
 
-    /* Get mutex. */
-    ENTER_PTHREAD_SECTION(&archiveMutex) {
+    {
+      TMutexLocker locker(&archiveMutex);
 
       /* Create archive file name. */
       uniqArcName = createArchiveName(nowTime);
@@ -400,8 +399,6 @@ int TLogManager::collectAllLog(jvmtiEnv *jvmti, JNIEnv *env, TInvokeCause cause,
         }
       }
     }
-    /* Release mutex. */
-    EXIT_PTHREAD_SECTION(&archiveMutex)
 
     /* If failure create archive file yet. */
     if (unlikely(result != 0)) {

--- a/agent/src/heapstats-engines/snapShotProcessor.cpp
+++ b/agent/src/heapstats-engines/snapShotProcessor.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file snapShotProcessor.cpp
  * \brief This file is used to output ranking and call snapshot function.
- * Copyright (C) 2011-2017 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2019 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -76,7 +76,9 @@ void JNICALL
     /* Is notify flag. */
     bool needProcess = false;
 
-    ENTER_PTHREAD_SECTION(&controller->mutex) {
+    {
+      TMutexLocker locker(&controller->mutex);
+
       if (likely(controller->_numRequests == 0)) {
         /* Wait for notification or termination. */
         pthread_cond_wait(&controller->mutexCond, &controller->mutex);
@@ -93,7 +95,6 @@ RACE_COND_DEBUG_POINT:
       /* Check remaining work. */
       existRemainder = (controller->_numRequests > 0);
     }
-    EXIT_PTHREAD_SECTION(&controller->mutex)
 
     /* If waiting is finished by notification. */
     if (needProcess && (snapshot != NULL)) {
@@ -158,7 +159,9 @@ void TSnapShotProcessor::notify(TSnapShotContainer *snapshot) {
 
   bool raiseException = true;
   /* Send notification and count notify. */
-  ENTER_PTHREAD_SECTION(&this->mutex) {
+  {
+    TMutexLocker locker(&this->mutex);
+
     try {
       /* Store and count data. */
       snapQueue.push(snapshot);
@@ -176,7 +179,6 @@ void TSnapShotProcessor::notify(TSnapShotContainer *snapshot) {
        */
     }
   }
-  EXIT_PTHREAD_SECTION(&this->mutex)
 
   if (unlikely(raiseException)) {
     throw "Failed to TSnapShotProcessor notify";

--- a/agent/src/heapstats-engines/trapSender.cpp
+++ b/agent/src/heapstats-engines/trapSender.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file trapSender.cpp
  * \brief This file is used to send SNMP trap.
- * Copyright (C) 2016-2017 Yasumasa Suenaga
+ * Copyright (C) 2016-2019 Yasumasa Suenaga
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -96,7 +96,9 @@ bool TTrapSender::initialize(int snmp, char *pPeer, char *pCommName, int port) {
   }
 
   /* Initialize session. */
-  ENTER_PTHREAD_SECTION(&senderMutex) {
+  {
+    TMutexLocker locker(&senderMutex);
+
     memset(&session, 0, sizeof(netsnmp_session));
     netSnmpFuncs.snmp_sess_init(&session);
     session.version = snmp;
@@ -104,7 +106,7 @@ bool TTrapSender::initialize(int snmp, char *pPeer, char *pCommName, int port) {
     session.remote_port = port;
     session.community = (u_char *)strdup(pCommName);
     session.community_len = (pCommName != NULL) ? strlen(pCommName) : 0;
-  } EXIT_PTHREAD_SECTION(&senderMutex)
+  }
 
   return true;
 }
@@ -114,11 +116,13 @@ bool TTrapSender::initialize(int snmp, char *pPeer, char *pCommName, int port) {
  */
 void TTrapSender::finalize(void) {
   /* Close and free SNMP session. */
-  ENTER_PTHREAD_SECTION(&senderMutex) {
+  {
+    TMutexLocker locker(&senderMutex);
+
     netSnmpFuncs.snmp_close(&session);
     free(session.peername);
     free(session.community);
-  } EXIT_PTHREAD_SECTION(&senderMutex)
+  }
 
   /* Unload library */
   if (libnetsnmp_handle != NULL) {
@@ -130,24 +134,24 @@ void TTrapSender::finalize(void) {
  * \brief TrapSender constructor.
  */
 TTrapSender::TTrapSender() {
-  /* Lock to use in multi-thread. */
-  ENTER_PTHREAD_SECTION(&senderMutex) {
+  {
+    TMutexLocker locker(&senderMutex);
+
     /* Disable NETSNMP logging. */
     netSnmpFuncs.netsnmp_register_loghandler(
                                NETSNMP_LOGHANDLER_NONE, LOG_EMERG);
     /* Make a PDU */
     pPdu = netSnmpFuncs.snmp_pdu_create(SNMP_MSG_TRAP2);
   }
-  /* Unlock to use in multi-thread. */
-  EXIT_PTHREAD_SECTION(&senderMutex)
 }
 
 /*!
  * \brief TrapSender destructor.
  */
 TTrapSender::~TTrapSender(void) {
-  /* Lock to use in multi-thread. */
-  ENTER_PTHREAD_SECTION(&senderMutex) {
+  {
+    TMutexLocker locker(&senderMutex);
+
     /* Clear Allocated str. */
     clearValues();
 
@@ -157,8 +161,6 @@ TTrapSender::~TTrapSender(void) {
     }
 
   }
-  /* Unlock to use in multi-thread. */
-  EXIT_PTHREAD_SECTION(&senderMutex)
 }
 
 /*!


### PR DESCRIPTION
This PR is for [Bug 3765](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3765)


We use `ENTER_PTHREAD_SECTION` and `EXIT_PTHREAD_SECTION` to enter/exit critical section which is managed by pthread mutex. They are macro, and it is difficult to release if caller jumps (e.g. `break` or `return` statement in loop).

Also we should abort if the mutex is not acquired / released.

I want them to migrate C++ class which acquires mutex in c'tor and releases in d'tor.


I want to work [Bug 3764](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3764) based on this enhancement.