### PR TITLE
Bug 3764: Agent thread might not be stopped when it works

### DIFF
--- a/agent/src/heapstats-engines/agentThread.cpp
+++ b/agent/src/heapstats-engines/agentThread.cpp
@@ -19,6 +19,8 @@
  *
  */
 
+#include <sched.h>
+
 #include "globals.hpp"
 #include "util.hpp"
 #include "agentThread.hpp"
@@ -134,7 +136,7 @@ void TAgentThread::stop(void) {
 
   /* SpinLock for AgentThread termination. */
   while (this->_isRunning) {
-    ; /* none. */
+    sched_yield();
   }
 
   /* Clean termination flag. */

--- a/agent/src/heapstats-engines/gcWatcher.cpp
+++ b/agent/src/heapstats-engines/gcWatcher.cpp
@@ -64,12 +64,16 @@ void JNICALL TGCWatcher::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
   controller->_isRunning = true;
 
   /* Loop for agent run. */
-  while (!controller->_terminateRequest) {
+  while (true) {
     /* Variable for notification flag. */
     bool needProcess = false;
 
     {
       TMutexLocker locker(&controller->mutex);
+
+      if (controller->_terminateRequest) {
+        break;
+      }
 
       /* If no exists request. */
       if (likely(controller->_numRequests == 0)) {

--- a/agent/src/heapstats-engines/snapShotProcessor.cpp
+++ b/agent/src/heapstats-engines/snapShotProcessor.cpp
@@ -71,13 +71,17 @@ void JNICALL
 
   bool existRemainder = false;
   /* Loop for agent run or remaining work exist. */
-  while (!controller->_terminateRequest || existRemainder) {
+  while (true) {
     TSnapShotContainer *snapshot = NULL;
     /* Is notify flag. */
     bool needProcess = false;
 
     {
       TMutexLocker locker(&controller->mutex);
+
+      if (unlikely(controller->_terminateRequest && !existRemainder)) {
+        break;
+      }
 
       if (likely(controller->_numRequests == 0)) {
         /* Wait for notification or termination. */

--- a/agent/src/heapstats-engines/timer.cpp
+++ b/agent/src/heapstats-engines/timer.cpp
@@ -72,12 +72,16 @@ void JNICALL TTimer::entryPoint(jvmtiEnv *jvmti, JNIEnv *jni, void *data) {
   controller->_isRunning = true;
 
   /* Loop for agent run. */
-  while (!controller->_terminateRequest) {
+  while (true) {
     /* Reset timer interrupt flag. */
     controller->_isInterrupted = false;
 
     {
       TMutexLocker locker(&controller->mutex);
+
+      if (unlikely(controller->_terminateRequest)) {
+        break;
+      }
 
       /* Create limit datetime. */
       struct timespec limitTs = {0};


### PR DESCRIPTION
This PR is for [Bug 3764](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3764)


The user reports their application could not be stopped due to HeapStats had not stopped GC Watcher thread [1].

I investigated it, and I think it is a bug in HeapStats.

HeapStats would set _terminateRequest to true, and would call pthraed_cond_signal(3) to wakeup agent thread. However, if agent thread works  (out of pthread critical section in entry point), agent thread would not be stopped.

According to manpage of pthread_cond_signal(3)[2], pthread_cond_signal(3) would not affect if there are no threads currently blocked on condition.

We need to ensure that agent thread is waiting when terminate request attempts to send.


[1] http://icedtea.classpath.org/pipermail/heapstats/2019-November/002412.html
[2] https://linux.die.net/man/3/pthread_cond_signal