### PR TITLE
Bug 3766: HeapStats Analyzer plugin does not work

### DIFF
--- a/README
+++ b/README
@@ -107,6 +107,10 @@ Oracle JDK can provide a real-time detection of JVM crash, but OpenJDK DOES NOT 
 * Apache Maven
 * JDK 13 or later
 
+## Add / Create Plugin
+
+HeapStats Analyzer supports custom plugin.  See [SamplePlugin](https://github.com/HeapStats/SamplePlugin) for details.
+
 # CLI #
 
 If you want to analyze data which are collected by HeapStats Agent on CUI environment, you can use HeapStats CLI.

--- a/analyzer/core/pom.xml
+++ b/analyzer/core/pom.xml
@@ -54,19 +54,16 @@
     </developers>
 
     <scm>
-        <url>http://icedtea.classpath.org/hg/heapstats</url>
-        <connection>scm:hg:http://icedtea.classpath.org/hg/heapstats</connection>
-        <developerConnection>scm:hg:ssh://icedtea.classpath.org/hg/heapstats</developerConnection>
+        <url>https://github.com/HeapStats/heapstats</url>
+        <connection>scm:git:https://github.com/HeapStats/heapstats.git</connection>
+        <developerConnection>scm:git:https://github.com/HeapStats/heapstats.git</developerConnection>
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <name>GitHub HeapStats Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/HeapStats/heapstats</url>
         </repository>
     </distributionManagement>
 
@@ -103,45 +100,6 @@
                 <version>3.0.2</version>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
@@ -157,34 +115,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <!-- releasing for maven repository, mvn -DperformRelease=true deploy -->
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/analyzer/fx/heapstats-analyzer
+++ b/analyzer/fx/heapstats-analyzer
@@ -1,3 +1,3 @@
 #!/bin/sh
 DIR=`dirname $0`
-$DIR/java --module-path $DIR/../mods -m heapstats.fx/jp.co.ntt.oss.heapstats.fx.HeapStatsFXAnalyzer $@
+$DIR/java --module-path $DIR/../mods -Dheapstats.boot.mode=jlink -m heapstats.fx/jp.co.ntt.oss.heapstats.fx.HeapStatsFXAnalyzer $@

--- a/analyzer/fx/heapstats-analyzer.bat
+++ b/analyzer/fx/heapstats-analyzer.bat
@@ -1,3 +1,3 @@
 @echo off
 set DIR=%~dp0
-"%DIR%\java" --module-path "%DIR%..\mods" -m heapstats.fx/jp.co.ntt.oss.heapstats.fx.HeapStatsFXAnalyzer %*
+"%DIR%\java" --module-path "%DIR%..\mods" -Dheapstats.boot.mode=jlink -m heapstats.fx/jp.co.ntt.oss.heapstats.fx.HeapStatsFXAnalyzer %*

--- a/analyzer/fx/src/main/assembly/distribution.xml
+++ b/analyzer/fx/src/main/assembly/distribution.xml
@@ -51,6 +51,11 @@
             </includes>
         </fileSet>
         <fileSet>
+            <!-- Empty directory -->
+            <outputDirectory>${file.separator}plugins</outputDirectory>
+            <excludes><exclude>**/*</exclude></excludes>
+        </fileSet>
+        <fileSet>
             <directory>${project.build.directory}${file.separator}dependency</directory>
             <outputDirectory>${file.separator}${file.separator}mods</outputDirectory>
             <includes>

--- a/analyzer/fx/src/main/java/module-info.java
+++ b/analyzer/fx/src/main/java/module-info.java
@@ -38,10 +38,10 @@ module heapstats.fx {
     
     exports jp.co.ntt.oss.heapstats.fx to javafx.graphics;
     opens jp.co.ntt.oss.heapstats.fx to javafx.fxml;
-    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.log to javafx.fxml;
+    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.log;
     opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.log.tabs to javafx.fxml;
-    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.snapshot to javafx.fxml;
+    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.snapshot;
     opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.snapshot.tabs to javafx.fxml;
-    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.threadrecorder to javafx.fxml;
-    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.jvmlive to javafx.fxml;
+    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.threadrecorder;
+    opens jp.co.ntt.oss.heapstats.fx.plugin.builtin.jvmlive;
 }

--- a/analyzer/plugin-api/pom.xml
+++ b/analyzer/plugin-api/pom.xml
@@ -53,19 +53,16 @@
     </developers>
 
     <scm>
-        <url>http://icedtea.classpath.org/hg/heapstats</url>
-        <connection>scm:hg:http://icedtea.classpath.org/hg/heapstats</connection>
-        <developerConnection>scm:hg:ssh://icedtea.classpath.org/hg/heapstats</developerConnection>
+        <url>https://github.com/HeapStats/heapstats</url>
+        <connection>scm:git:https://github.com/HeapStats/heapstats.git</connection>
+        <developerConnection>scm:git:https://github.com/HeapStats/heapstats.git</developerConnection>
     </scm>
 
     <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>github</id>
+            <name>GitHub HeapStats Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/HeapStats/heapstats</url>
         </repository>
     </distributionManagement>
 
@@ -124,45 +121,6 @@
                 <version>3.0.2</version>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.8</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <phase>deploy</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
@@ -178,34 +136,4 @@
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release-sign-artifacts</id>
-            <!-- releasing for maven repository, mvn -DperformRelease=true deploy -->
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
This PR is for [Bug 3766](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3766)


HeapStats Analyzer suppports module (Jigsaw) since v2.2 .
However Analyzer Plugin does not support it.

Also I migrated Maven modules for HeapStats Analyzer to GitHub Package Registry. So I include the fix for it in POM.

  https://github.com/HeapStats/heapstats/packages

All changes of this work are available on [github-mvn-pkg](https://github.com/HeapStats/heapstats/tree/github-mvn-pkg) branch.  This PR excludes commits for artifact version in POM.

Plugin example which uses this change is available on [for2.2 branch on SamplePlugin](https://github.com/HeapStats/SamplePlugin/tree/for2.2).