### PR TITLE
Bug 3767: Compiler warnings at `snmp_session::remote_port`

### DIFF
--- a/agent/src/heapstats-engines/trapSender.cpp
+++ b/agent/src/heapstats-engines/trapSender.cpp
@@ -77,6 +77,9 @@ netsnmp_session TTrapSender::session;
  * \param port      [in] Port used by SNMP trap.
  * \return true if succeeded.
  */
+// Avoid deprecation warning of snmp_session::remote_port
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 bool TTrapSender::initialize(int snmp, char *pPeer, char *pCommName, int port) {
   /* If snmp target is illegal. */
   if (pPeer == NULL) {
@@ -110,6 +113,7 @@ bool TTrapSender::initialize(int snmp, char *pPeer, char *pCommName, int port) {
 
   return true;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief TTrapSender global finalization.
@@ -244,6 +248,9 @@ int TTrapSender::addValue(oid id[], int len, const char *pValue, char type) {
  * \brief Add variable as send information by trap.
  * \return Return process result code.
  */
+// Avoid deprecation warning of snmp_session::remote_port
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 int TTrapSender::sendTrap(void) {
   /* If snmp target is illegal. */
   if (pPdu == NULL) {
@@ -313,6 +320,7 @@ int TTrapSender::sendTrap(void) {
 
   return (success) ? SNMP_PROC_SUCCESS : SNMP_PROC_FAILURE;
 }
+#pragma GCC diagnostic pop
 
 /*!
  * \brief Clear PDU and allocated strings.


### PR DESCRIPTION
This PR is for [Bug 3767](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3767).

I saw deprecation message as below when I compiled HeapStats agent on Fedora 31 (with net-snmp-devel-5.8-11.fc31.x86_64):

```
trapSender.cpp:106:13: warning: 'snmp_session::remote_port' is deprecated [-Wdeprecated-declarations]
  106 |     session.remote_port = port;
      |             ^~~~~~~~~~~
In file included from /usr/include/net-snmp/definitions.h:22,
                 from /usr/include/net-snmp/net-snmp-includes.h:67,
                 from trapSender.cpp:25:
/usr/include/net-snmp/types.h:345:21: note: declared here
  345 |     u_short         remote_port NETSNMP_ATTRIBUTE_DEPRECATED;
      |                     ^~~~~~~~~~~
trapSender.cpp:106:13: warning: 'snmp_session::remote_port' is deprecated [-Wdeprecated-declarations]
  106 |     session.remote_port = port;
      |
```

This deprecation has been appeared since [this commit](https://sourceforge.net/p/net-snmp/code/ci/06bfd94bc00509146e84752065bd2669fc3bc828/), however it did not remove related code - just add deprecation flag.

So I want to disable it with -Wdeprecated-declarations at this point.