### PR TITLE
Bug 3791: HeapStats agent should show warning if it run on JDK 8u262 or later

### DIFF
--- a/README
+++ b/README
@@ -36,7 +36,7 @@ More detailes are [here](http://icedtea.classpath.org/wiki/HeapStats/information
 * Linux x64 / x86_64 / AArch32
 * Oracle JDK / OpenJDK 6u18 or later
 
-**NOTE: We recommend not to use on JDK 8u262 or later due to JFR backport**
+**NOTE: For JDK 8u262 or later, we recommend to use built-in agent, JDK Flight Recorder, instead of HeapStats**
 
 ## How to use ##
 
@@ -156,4 +156,3 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 # License #
 
 [GNU General Public License, version 2](COPYING)
-

--- a/README
+++ b/README
@@ -36,6 +36,8 @@ More detailes are [here](http://icedtea.classpath.org/wiki/HeapStats/information
 * Linux x64 / x86_64 / AArch32
 * Oracle JDK / OpenJDK 6u18 or later
 
+**NOTE: We recommend not to use on JDK 8u262 or later due to JFR backport**
+
 ## How to use ##
 
 You can attach HeapStats agent by any way of the following:

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -539,7 +539,5 @@ void TJvmInfo::detectDelayInfoAddress(void) {
     if ((major == 8) && (update >= 262)) {
       logger->printWarnMsg("JDK %s is not recommended due to JFR backport", this->_javaVersion);
     }
-  } else {
-    logger->printWarnMsg("Invalid JDK version: %s", this->_javaVersion);
   }
 }

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -1,7 +1,7 @@
 /*!
  * \file jvmInfo.cpp
  * \brief This file is used to get JVM performance information.
- * Copyright (C) 2011-2016 Nippon Telegraph and Telephone Corporation
+ * Copyright (C) 2011-2020 Nippon Telegraph and Telephone Corporation
  *
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -525,5 +525,21 @@ void TJvmInfo::detectDelayInfoAddress(void) {
   /* JEP 220: Modular Run-Time Images */
   if (!isAfterJDK9()) {
     loadDelayLogFlag &= (_endorsedPath != NULL) && (_bootClassPath != NULL);
+  }
+
+  /* JFR-backported JDK 8 is not supported */
+#if USE_PCRE
+  TPCRERegex versionRegex("^\\d+\\.(\\d+)\\.\\d+_(\\d+)[^0-9]*$", 6);
+#else
+  TCPPRegex versionRegex("^\\d+\\.(\\d+)\\.\\d+_(\\d+)[^0-9]*$");
+#endif
+  if (versionRegex.find(this->_javaVersion)) {
+    int major = atoi(versionRegex.group(1));
+    int update = atoi(versionRegex.group(2));
+    if ((major == 8) && (update >= 262)) {
+      logger->printWarnMsg("JDK %s is not recommended due to JFR backport", this->_javaVersion);
+    }
+  } else {
+    logger->printWarnMsg("Invalid JDK version: %s", this->_javaVersion);
   }
 }

--- a/agent/src/heapstats-engines/jvmInfo.cpp
+++ b/agent/src/heapstats-engines/jvmInfo.cpp
@@ -529,7 +529,7 @@ void TJvmInfo::detectDelayInfoAddress(void) {
 
   /* JFR-backported JDK 8 is not supported */
 #if USE_PCRE
-  TPCRERegex versionRegex("^\\d+\\.(\\d+)\\.\\d+_(\\d+)[^0-9]*$", 6);
+  TPCRERegex versionRegex("^\\d+\\.(\\d+)\\.\\d+_(\\d+)[^0-9]*$", 9);
 #else
   TCPPRegex versionRegex("^\\d+\\.(\\d+)\\.\\d+_(\\d+)[^0-9]*$");
 #endif


### PR DESCRIPTION
This PR is for [Bug 3791](https://icedtea.classpath.org/bugzilla/show_bug.cgi?id=3791)

JFR is backported to JDK 8u262 in [JDK-8223147](https://bugs.openjdk.java.net/browse/JDK-8223147).

However, unfortunately I have to say you HeapStats agent may not work well on 8u262 or later.

In JFR on jdk/jdk (OpenJDK upstream) collects data in OopClosure, so it might conflict with HeapStats, and might affects each other. (I'm not sure it in JDK 8 because I haven't seen backported JFR code in JDK 8.)

Anyway, I recommend you not to use HeapStats on 8u262 or later, and I will add warning message when you use HeapStats on them.
If you want to check Java heap on 8u262 or later, I recommend you to use JFR.